### PR TITLE
chore(release): v1.2.8 DockerHub workflow + embedding cache defaults

### DIFF
--- a/.github/workflows/release-dockerhub.yml
+++ b/.github/workflows/release-dockerhub.yml
@@ -1,0 +1,51 @@
+name: Release Docker image (Docker Hub)
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: mumujie/mumuainovel
+
+jobs:
+  build-and-push:
+    name: Build and push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -100,7 +100,8 @@ htmlcov/
 dmypy.json
 
 # Local test & backup files
-.github/
+.github/copilot-instructions.md
+diagnostics/
 DATABASE_BACKUP_GUIDE.md
 backend/embedding/models--sentence-transformers--paraphrase-multilingual-MiniLM-L12-v2/embedding.zip
 backups/

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ COPY backend/scripts/migrate.py ./scripts/migrate.py
 RUN chmod +x /app/entrypoint.sh
 
 # 创建必要的目录
-RUN mkdir -p /app/data /app/logs
+RUN mkdir -p /app/data /app/logs /app/embedding
 
 # 暴露端口
 EXPOSE 8000
@@ -74,10 +74,14 @@ ENV PYTHONUNBUFFERED=1
 ENV APP_HOST=0.0.0.0
 ENV APP_PORT=8000
 
-# 设置Transformers和Sentence-Transformers离线模式
-ENV TRANSFORMERS_OFFLINE=1
-ENV HF_DATASETS_OFFLINE=1
-ENV HF_HUB_OFFLINE=1
+# Transformers/Sentence-Transformers 默认允许联网下载（首次启动会缓存到 /app/embedding）
+# 如需强制离线运行，可在 docker-compose/.env 中设置：
+#   TRANSFORMERS_OFFLINE=1
+#   HF_DATASETS_OFFLINE=1
+#   HF_HUB_OFFLINE=1
+ENV TRANSFORMERS_OFFLINE=0
+ENV HF_DATASETS_OFFLINE=0
+ENV HF_HUB_OFFLINE=0
 ENV SENTENCE_TRANSFORMERS_HOME=/app/embedding
 
 # 健康检查

--- a/README.md
+++ b/README.md
@@ -174,12 +174,12 @@ docker-compose up -d
 >
 > 1. **`.env` 文件挂载**: `docker-compose.yml` 会自动将 `.env` 挂载到容器，确保文件存在
 > 2. **数据库初始化**: `init_postgres.sql` 会在首次启动时自动执行，安装必要的PostgreSQL扩展
-> 3. **自行构建**: 如需从源码构建，请先下载 embedding 模型文件（[加群获取](frontend/public/qq.jpg)）
+> 3. **Embedding 模型**: 默认首次启动会自动从 HuggingFace 下载（约 400MB）并缓存；离线环境可提前手动准备模型文件
 
 ### 使用 Docker Hub 镜像（推荐新手）
 
 ```bash
-# 1. 拉取最新镜像（已包含模型文件）
+# 1. 拉取最新镜像（首次启动会自动下载 embedding 模型并缓存）
 docker pull mumujie/mumuainovel:latest
 
 # 2. 创建 docker-compose.yml（点击下方展开查看完整配置）
@@ -251,10 +251,12 @@ services:
     volumes:
       - ./logs:/app/logs
       - ./.env:/app/.env:ro
+      # Embedding 模型缓存（首次可自动下载，后续复用；不增加镜像体积）
+      - embedding_cache:/app/embedding
     environment:
       # 应用配置
       - APP_NAME=${APP_NAME:-MuMuAINovel}
-      - APP_VERSION=${APP_VERSION:-1.0.0}
+      - APP_VERSION=${APP_VERSION:-1.2.8}
       - APP_HOST=${APP_HOST:-0.0.0.0}
       - APP_PORT=8000
       - DEBUG=${DEBUG:-false}
@@ -311,6 +313,8 @@ services:
 volumes:
   postgres_data:
     driver: local
+  embedding_cache:
+    driver: local
 
 networks:
   ai-story-network:
@@ -331,21 +335,19 @@ docker-compose pull
 docker-compose up -d
 ```
 
-> **💡 提示**: Docker Hub 镜像已包含所有依赖和模型文件，无需额外下载
+> **💡 提示**: 首次启动会自动下载 embedding 模型并缓存到 `embedding_cache` 卷，后续启动无需重复下载
 
 ### 本地开发 / 从源码构建
 
 #### 前置准备
 
 ```bash
-# ⚠️ 重要：如果从源码构建，需要先下载 embedding 模型文件
-# 模型文件较大（约 400MB），需放置到以下目录：
-# backend/embedding/models--sentence-transformers--paraphrase-multilingual-MiniLM-L12-v2/
-#
-# 📥 获取方式：
-# - 加入项目 QQ 群或 Linux DO 讨论区获取下载链接
-# - 群号：见项目主页
-# - Linux DO：https://linux.do/t/topic/1100112
+# Embedding 模型（约 400MB）默认会在首次启动时从 HuggingFace 自动下载，
+# 并缓存到容器内的 /app/embedding（建议用 volume 挂载，docker-compose 已配置 embedding_cache）。
+# 如果你需要离线部署，可提前把模型放到 backend/embedding/... 并在运行时设置：
+#   TRANSFORMERS_OFFLINE=1
+#   HF_DATASETS_OFFLINE=1
+#   HF_HUB_OFFLINE=1
 ```
 
 #### 后端

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,2 +1,2 @@
 """AI Story Creator - 后端应用包"""
-__version__ = "1.0.0"
+__version__ = "1.2.8"

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -25,7 +25,7 @@ class Settings(BaseSettings):
     
     # 应用配置
     app_name: str = "MuMuAINovel"
-    app_version: str = "1.0.0"
+    app_version: str = "1.2.8"
     app_host: str = "0.0.0.0"
     app_port: int = 8000
     debug: bool = True

--- a/backend/scripts/entrypoint.sh
+++ b/backend/scripts/entrypoint.sh
@@ -10,7 +10,7 @@ if [ -z "$APP_VERSION" ]; then
     if [ -f "/app/.env.example" ]; then
         APP_VERSION=$(grep "^APP_VERSION=" /app/.env.example | cut -d '=' -f2)
     fi
-    APP_VERSION="${APP_VERSION:-1.0.0}"
+    APP_VERSION="${APP_VERSION:-1.2.8}"
 fi
 
 if [ -z "$APP_NAME" ]; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,10 +63,12 @@ services:
     volumes:
       - ./logs:/app/logs
       - ./.env:/app/.env:ro
+      # Embedding 模型缓存（首次可自动下载，后续复用；不增加镜像体积）
+      - embedding_cache:/app/embedding
     environment:
       # 应用配置
       - APP_NAME=${APP_NAME:-MuMuAINovel}
-      - APP_VERSION=${APP_VERSION:-1.0.0}
+      - APP_VERSION=${APP_VERSION:-1.2.8}
       - APP_HOST=${APP_HOST:-0.0.0.0}
       - APP_PORT=8000
       - DEBUG=${DEBUG:-false}
@@ -131,6 +133,8 @@ services:
 
 volumes:
   postgres_data:
+    driver: local
+  embedding_cache:
     driver: local
 
 networks:


### PR DESCRIPTION
## 目的
- 发版闭环：GitHub 打 tag 自动构建并推送 DockerHub 镜像。
- 体积优先：镜像默认不打包 embedding 模型，首次启动允许从 HuggingFace 下载并缓存到 volume。

## 主要改动
- 新增工作流：.github/workflows/release-dockerhub.yml（tag v* → push DockerHub 1.2.8 + latest，linux/amd64）
- Docker/Compose：默认允许联网下载 transformers 模型 + `embedding_cache` 卷缓存 `/app/embedding`
- README：修正文案与 compose 示例，明确首次自动下载并缓存

## Secrets（必需）
GitHub Settings → Secrets and variables → Actions：
- `DOCKERHUB_USERNAME`
- `DOCKERHUB_TOKEN`

## 发版
```bash
git tag v1.2.8
git push origin v1.2.8
```
