### PR TITLE
fix: 修复MCP插件创建和测试时的500错误

### DIFF
--- a/backend/app/mcp/status_sync.py
+++ b/backend/app/mcp/status_sync.py
@@ -3,6 +3,7 @@
 将内存中的会话状态变更同步到数据库，确保状态一致性。
 """
 
+import asyncio
 from typing import Dict, Any
 from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -12,22 +13,42 @@ from app.logger import get_logger
 
 logger = get_logger(__name__)
 
+# 状态同步队列
+_sync_queue: asyncio.Queue = None
+_sync_task: asyncio.Task = None
 
-async def sync_status_to_db(event: Dict[str, Any]):
-    """
-    状态变更回调 - 同步到数据库
-    """
+
+async def _sync_worker():
+    """后台状态同步工作线程"""
+    global _sync_queue
+
+    while True:
+        try:
+            event = await _sync_queue.get()
+            if event is None:  # 停止信号
+                break
+
+            await _do_sync_status(event)
+            _sync_queue.task_done()
+        except asyncio.CancelledError:
+            break
+        except Exception as e:
+            logger.error(f"状态同步工作线程异常: {e}")
+
+
+async def _do_sync_status(event: Dict[str, Any]):
+    """实际执行状态同步"""
     user_id = event["user_id"]
     plugin_name = event["plugin_name"]
     new_status = event["new_status"]
     reason = event.get("reason", "")
-    
+
     try:
         from app.database import get_engine
-        
+
         engine = await get_engine(user_id)
         AsyncSessionLocal = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
-        
+
         async with AsyncSessionLocal() as db:
             stmt = (
                 update(MCPPlugin)
@@ -36,11 +57,34 @@ async def sync_status_to_db(event: Dict[str, Any]):
             )
             await db.execute(stmt)
             await db.commit()
-            
+
             logger.debug(f"✅ 状态已同步到数据库: {plugin_name} -> {new_status}")
-            
+
     except Exception as e:
         logger.error(f"❌ 状态同步失败: {plugin_name}, 错误: {e}")
+
+
+async def sync_status_to_db(event: Dict[str, Any]):
+    """
+    状态变更回调 - 将事件加入队列异步同步到数据库
+
+    使用队列异步处理，避免在请求处理过程中阻塞或产生数据库连接冲突
+    """
+    global _sync_queue, _sync_task
+
+    # 延迟初始化队列和工作线程
+    if _sync_queue is None:
+        _sync_queue = asyncio.Queue()
+
+    if _sync_task is None or _sync_task.done():
+        _sync_task = asyncio.create_task(_sync_worker())
+        logger.info("✅ MCP状态同步工作线程已启动")
+
+    # 将事件加入队列（非阻塞）
+    try:
+        _sync_queue.put_nowait(event)
+    except asyncio.QueueFull:
+        logger.warning(f"状态同步队列已满，丢弃事件: {event['plugin_name']}")
 
 
 def register_status_sync():


### PR DESCRIPTION
## 问题描述

MCP 插件创建和测试时报 500 错误：`RuntimeError: No response returned`

## 根本原因

MCP SDK 使用 anyio TaskGroup，与 FastAPI 请求上下文不兼容。当在请求中直接 await MCP 操作时，会触发取消域冲突。

## 解决方案

1. **后台任务执行 MCP 连接**：将 MCP 连接操作放到 `asyncio.create_task()` 中执行，避免阻塞请求
2. **同步检查方法**：添加 `is_registered()` 和 `get_session_status()` 同步方法，用于检查会话状态
3. **两阶段测试流程**：
   - 第一次测试：如果会话不存在，启动后台注册，返回"正在连接"提示
   - 第二次测试：会话已存在，直接执行测试
4. **改进错误处理**：处理 `ExceptionGroup` 异常，显示详细错误信息
5. **异步队列状态同步**：状态同步改用异步队列，避免阻塞

## 修改文件

| 文件 | 修改内容 |
|------|----------|
| `backend/app/api/mcp_plugins.py` | 重写 `test_plugin` 和 `create_plugin_simple`，使用后台任务 |
| `backend/app/mcp/facade.py` | 添加 `is_registered()` 和 `get_session_status()` 同步方法，改进错误处理 |
| `backend/app/mcp/status_sync.py` | 使用异步队列同步状态到数据库 |
| `backend/app/services/mcp_test_service.py` | 使用同步检查代替异步 `ensure_registered()` |

## 测试

- [x] MCP 插件创建成功
- [x] MCP 插件测试成功
- [x] SSL 证书验证正常（证书链完整后）