### PR TITLE
feat: 添加展开规划编辑功能 (#76)

### DIFF
--- a/frontend/src/pages/Outline.tsx
+++ b/frontend/src/pages/Outline.tsx
@@ -1,13 +1,14 @@
 ﻿import { useState, useEffect } from 'react';
 import { Button, List, Modal, Form, Input, message, Empty, Space, Popconfirm, Card, Select, Radio, Tag, InputNumber, Tabs } from 'antd';
-import { EditOutlined, DeleteOutlined, ThunderboltOutlined, BranchesOutlined, AppstoreAddOutlined, CheckCircleOutlined, ExclamationCircleOutlined, PlusOutlined, FileTextOutlined } from '@ant-design/icons';
+import { EditOutlined, DeleteOutlined, ThunderboltOutlined, BranchesOutlined, AppstoreAddOutlined, CheckCircleOutlined, ExclamationCircleOutlined, PlusOutlined, FileTextOutlined, FormOutlined } from '@ant-design/icons';
 import { useStore } from '../store';
 import { useOutlineSync } from '../store/hooks';
 import { cardStyles } from '../components/CardStyles';
 import { SSEPostClient } from '../utils/sseClient';
 import { SSEProgressModal } from '../components/SSEProgressModal';
+import ExpansionPlanEditor from '../components/ExpansionPlanEditor';
 import { outlineApi, chapterApi, projectApi } from '../services/api';
-import type { OutlineExpansionResponse, BatchOutlineExpansionResponse, ChapterPlanItem, ApiError } from '../types';
+import type { OutlineExpansionResponse, BatchOutlineExpansionResponse, ChapterPlanItem, ApiError, ExpansionPlanData } from '../types';
 
 // 角色预测数据类型
 interface PredictedCharacter {
@@ -141,6 +142,11 @@ export default function Outline() {
   const [sseProgress, setSSEProgress] = useState(0);
   const [sseMessage, setSSEMessage] = useState('');
   const [sseModalVisible, setSSEModalVisible] = useState(false);
+
+  // 编辑规划的状态
+  const [editingPlanChapterId, setEditingPlanChapterId] = useState<string | null>(null);
+  const [editingPlanData, setEditingPlanData] = useState<ExpansionPlanData | null>(null);
+  const [planEditorVisible, setPlanEditorVisible] = useState(false);
 
   useEffect(() => {
     const handleResize = () => {
@@ -1025,6 +1031,48 @@ export default function Outline() {
     }
   };
 
+  // 打开编辑规划对话框
+  const handleEditExpansionPlan = (chapterId: string, planData: ExpansionPlanData) => {
+    setEditingPlanChapterId(chapterId);
+    setEditingPlanData(planData);
+    setPlanEditorVisible(true);
+    Modal.destroyAll(); // 关闭预览对话框
+  };
+
+  // 保存规划信息
+  const handleSaveExpansionPlan = async (planData: ExpansionPlanData) => {
+    if (!editingPlanChapterId || !currentProject?.id) return;
+
+    try {
+      const response = await fetch(`/api/chapters/${editingPlanChapterId}/expansion-plan`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(planData),
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.detail || '更新失败');
+      }
+
+      message.success('规划信息更新成功');
+
+      // 关闭编辑器
+      setPlanEditorVisible(false);
+      setEditingPlanChapterId(null);
+      setEditingPlanData(null);
+
+      // 刷新大纲列表
+      await refreshOutlines();
+    } catch (error: unknown) {
+      const err = error as Error;
+      message.error('保存规划失败：' + (err.message || '未知错误'));
+      throw error;
+    }
+  };
+
   // 显示已存在章节的展开规划
   const showExistingExpansionPreview = (
     outlineTitle: string,
@@ -1274,8 +1322,31 @@ export default function Outline() {
                           ))}
                         </Space>
                       </Card>
-                    )
-                    }
+                    )}
+
+                    {/* 编辑规划按钮 */}
+                    <Button
+                      type="primary"
+                      icon={<FormOutlined />}
+                      onClick={() => {
+                        const chapterId = data.chapters[idx]?.id;
+                        if (chapterId) {
+                          handleEditExpansionPlan(chapterId, {
+                            key_events: plan.key_events,
+                            character_focus: plan.character_focus,
+                            emotional_tone: plan.emotional_tone,
+                            narrative_goal: plan.narrative_goal,
+                            conflict_type: plan.conflict_type,
+                            estimated_words: plan.estimated_words,
+                            scenes: plan.scenes || null
+                          });
+                        }
+                      }}
+                      block
+                      style={{ marginTop: 8 }}
+                    >
+                      编辑此章节规划
+                    </Button>
                   </Space>
                 </div >
               )
@@ -2539,6 +2610,22 @@ export default function Outline() {
           )}
         </div>
       </div>
+
+      {/* 规划编辑器 */}
+      {currentProject && editingPlanChapterId && (
+        <ExpansionPlanEditor
+          visible={planEditorVisible}
+          planData={editingPlanData}
+          chapterSummary={null}
+          projectId={currentProject.id}
+          onSave={handleSaveExpansionPlan}
+          onCancel={() => {
+            setPlanEditorVisible(false);
+            setEditingPlanChapterId(null);
+            setEditingPlanData(null);
+          }}
+        />
+      )}
     </>
   );
 }


### PR DESCRIPTION
## 问题描述

修复 Issue #76

在细化模式（1-N）中，当章节大纲被展开后，用户无法对这些展开的章节规划进行编辑。

## 解决方案

为展开规划预览界面的每个章节添加「编辑此章节规划」按钮，点击后可以打开编辑器修改规划内容。

## 主要改动

### 前端修改 (`frontend/src/pages/Outline.tsx`)

1. **导入必要组件**
   - 导入 `ExpansionPlanEditor` 组件
   - 导入 `FormOutlined` 图标
   - 导入 `ExpansionPlanData` 类型

2. **添加状态管理**
   - `editingPlanChapterId`: 当前编辑的章节ID
   - `editingPlanData`: 当前编辑的规划数据
   - `planEditorVisible`: 编辑器显示状态

3. **实现编辑功能**
   - `handleEditExpansionPlan`: 打开编辑器并传入规划数据
   - `handleSaveExpansionPlan`: 调用 API 保存修改后的规划

4. **UI 改进**
   - 在每个章节规划卡片底部添加「编辑此章节规划」按钮
   - 点击按钮关闭预览对话框并打开编辑器
   - 保存成功后自动刷新大纲列表

5. **渲染编辑器组件**
   - 在组件末尾条件渲染 `ExpansionPlanEditor`

## 功能特性

- ✅ 支持编辑关键事件列表
- ✅ 支持编辑涉及角色
- ✅ 支持编辑情感基调
- ✅ 支持编辑叙事目标
- ✅ 支持编辑冲突类型
- ✅ 支持编辑预估字数
- ✅ 保留场景信息（如果有）
- ✅ 保存后自动刷新显示

## 后端支持

使用现有的 API 端点：`PUT /api/chapters/{chapter_id}/expansion-plan`

无需修改后端代码。

## 测试建议

1. 创建一个使用细化模式（1-N）的项目
2. 创建大纲并展开为多章
3. 点击展开信息查看规划
4. 点击「编辑此章节规划」按钮
5. 修改规划内容并保存
6. 验证修改是否成功保存并显示

## 截图

（建议项目维护者在测试后添加截图）

## 相关 Issue

Closes #76