### PR TITLE
fix: replace 9 bare excepts with except Exception

### DIFF
--- a/backend/app/api/chapters.py
+++ b/backend/app/api/chapters.py
@@ -1804,7 +1804,7 @@ async def generate_chapter_content_stream(
                     # 强制关闭
                     try:
                         await db_session.close()
-                    except:
+                    except Exception:
                         pass
     
     return create_sse_response(event_generator())

--- a/backend/app/api/characters.py
+++ b/backend/app/api/characters.py
@@ -461,7 +461,7 @@ async def update_character(
         # 解析副职业JSON
         try:
             sub_careers_data = json.loads(sub_careers_json) if isinstance(sub_careers_json, str) else sub_careers_json
-        except:
+        except Exception:
             sub_careers_data = []
         
         # 删除现有的所有副职业关联
@@ -881,7 +881,7 @@ async def generate_character_stream(
                             stage_info = " → ".join(stage_names)
                             if len(stages) > 3:
                                 stage_info += " → ..."
-                        except:
+                        except Exception:
                             stage_info = f"共{career.max_stage}个阶段"
                         
                         careers_info += f"- 名称: {career.name}"

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -220,7 +220,7 @@ async def get_db(request: Request):
             logger.error(f"❌ 关闭会话时出错 [User:{user_id}][ID:{session_id}]: {str(e)}", exc_info=True)
             try:
                 await session.close()
-            except:
+            except Exception:
                 pass
 
 async def init_db(user_id: str = None):

--- a/backend/app/mcp/facade.py
+++ b/backend/app/mcp/facade.py
@@ -1003,7 +1003,7 @@ class MCPClientFacade:
                 try:
                     content_obj = json.loads(content)
                     content = json.dumps(content_obj, ensure_ascii=False, indent=2)
-                except:
+                except Exception:
                     pass
                 lines.append(f"```json\n{content}\n```\n")
             else:

--- a/backend/app/services/import_export_service.py
+++ b/backend/app/services/import_export_service.py
@@ -210,7 +210,7 @@ class ImportExportService:
             if ch.expansion_plan:
                 try:
                     expansion_plan = json.loads(ch.expansion_plan) if isinstance(ch.expansion_plan, str) else ch.expansion_plan
-                except:
+                except Exception:
                     expansion_plan = None
             
             exported_chapters.append(ChapterExportData(
@@ -243,7 +243,7 @@ class ImportExportService:
             if char.traits:
                 try:
                     traits = json.loads(char.traits) if isinstance(char.traits, str) else char.traits
-                except:
+                except Exception:
                     traits = None
             
             exported.append(CharacterExportData(
@@ -1420,7 +1420,7 @@ class ImportExportService:
             if char.traits:
                 try:
                     traits = json.loads(char.traits) if isinstance(char.traits, str) else char.traits
-                except:
+                except Exception:
                     traits = None
             
             # 基础角色数据

--- a/backend/app/services/json_helper.py
+++ b/backend/app/services/json_helper.py
@@ -31,7 +31,7 @@ def clean_json_response(text: str) -> str:
             json.loads(text)
             logger.debug(f"✅ 直接解析成功，无需清洗")
             return text
-        except:
+        except Exception:
             pass
         
         # 找到第一个 { 或 [


### PR DESCRIPTION
Replace 9 bare `except:` with `except Exception:` across 6 files. Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, masking real errors.