### PR TITLE
update：优化设置同步与首页响应式体验，修复生成内容与菜单交互问题

### DIFF
--- a/backend/app/api/chapters.py
+++ b/backend/app/api/chapters.py
@@ -55,6 +55,7 @@ from app.services.plot_analyzer import PlotAnalyzer
 from app.services.memory_service import memory_service
 from app.services.foreshadow_service import foreshadow_service
 from app.services.chapter_regenerator import ChapterRegenerator
+from app.services.json_helper import NovelContentFilter, clean_novel_content
 from app.logger import get_logger
 from app.api.settings import get_user_ai_service
 from app.utils.sse_response import SSEResponse, create_sse_response
@@ -1650,6 +1651,7 @@ async def generate_chapter_content_stream(
                 # === 生成阶段 ===
                 full_content = ""
                 chunk_count = 0
+                content_filter = NovelContentFilter()
                 
                 yield await tracker.generating(
                     current_chars=0,
@@ -1657,25 +1659,51 @@ async def generate_chapter_content_stream(
                 )
                 
                 async for chunk in user_ai_service.generate_text_stream(**generate_kwargs):
-                    full_content += chunk
-                    chunk_count += 1
+                    # 过滤 think/meta 内容（支持跨 chunk 标签）
+                    filtered_chunk = content_filter.filter_chunk(chunk)
                     
-                    # 发送内容块
-                    yield await tracker.generating_chunk(chunk)
-                    
-                    # 每5个chunk发送一次进度更新
-                    if chunk_count % 5 == 0:
-                        yield await tracker.generating(
-                            current_chars=len(full_content),
-                            estimated_total=target_word_count,
-                            message=f'正在创作中... 已生成 {len(full_content)} 字'
-                        )
-                    
-                    # 每20个chunk发送心跳
-                    if chunk_count % 20 == 0:
-                        yield await tracker.heartbeat()
-                    
-                    await asyncio.sleep(0)  # 让出控制权
+                    if filtered_chunk:  # 只处理非空的过滤后内容
+                        full_content += filtered_chunk
+                        chunk_count += 1
+                        
+                        # 发送内容块
+                        yield await tracker.generating_chunk(filtered_chunk)
+                        
+                        # 每5个chunk发送一次进度更新
+                        if chunk_count % 5 == 0:
+                            yield await tracker.generating(
+                                current_chars=len(full_content),
+                                estimated_total=target_word_count,
+                                message=f'正在创作中... 已生成 {len(full_content)} 字'
+                            )
+                        
+                        # 每20个chunk发送心跳
+                        if chunk_count % 20 == 0:
+                            yield await tracker.heartbeat()
+                        
+                        await asyncio.sleep(0)  # 让出控制权
+                
+                # 刷新过滤器缓冲区，确保 </think> 后尾部正文不会丢失
+                final_chunk = content_filter.flush()
+                if final_chunk:
+                    full_content += final_chunk
+                    yield await tracker.generating_chunk(final_chunk)
+
+                if content_filter.removed_think_chars > 0 or content_filter.removed_meta_lines > 0:
+                    logger.debug(
+                        "章节流式生成已过滤思考/元信息: removed_think_chars=%s, removed_meta_lines=%s",
+                        content_filter.removed_think_chars,
+                        content_filter.removed_meta_lines,
+                    )
+
+                # 兜底清洗：确保最终入库内容不残留 think/meta
+                sanitized_content = clean_novel_content(full_content)
+                if len(sanitized_content) != len(full_content):
+                    logger.debug(
+                        "章节流式生成保存前二次清洗生效: removed_chars=%s",
+                        len(full_content) - len(sanitized_content),
+                    )
+                full_content = sanitized_content
                 
                 # === 保存阶段 ===
                 yield await tracker.saving("正在保存章节...", 0.3)
@@ -3183,9 +3211,29 @@ async def generate_single_chapter_for_batch(
         generate_kwargs["model"] = custom_model
         logger.info(f"  批量生成使用自定义模型: {custom_model}")
     
-    # 批量生成中的流式生成（非SSE，不需要修改进度显示）
+    # 批量生成中的流式生成（非SSE）同样需要过滤思考/元信息，保证入库内容干净
+    content_filter = NovelContentFilter()
     async for chunk in ai_service.generate_text_stream(**generate_kwargs):
-        full_content += chunk
+        full_content += content_filter.filter_chunk(chunk)
+    full_content += content_filter.flush()
+
+    if content_filter.removed_think_chars > 0 or content_filter.removed_meta_lines > 0:
+        logger.debug(
+            "批量生成已过滤思考/元信息: chapter=%s, removed_think_chars=%s, removed_meta_lines=%s",
+            chapter.chapter_number,
+            content_filter.removed_think_chars,
+            content_filter.removed_meta_lines,
+        )
+
+    # 兜底清洗：保证批量任务最终入库内容一致过滤
+    sanitized_content = clean_novel_content(full_content)
+    if len(sanitized_content) != len(full_content):
+        logger.debug(
+            "批量生成保存前二次清洗生效: chapter=%s, removed_chars=%s",
+            chapter.chapter_number,
+            len(full_content) - len(sanitized_content),
+        )
+    full_content = sanitized_content
     
     # 更新章节内容到数据库（使用锁保护）
     async with write_lock:

--- a/backend/app/api/settings.py
+++ b/backend/app/api/settings.py
@@ -804,6 +804,17 @@ async def get_user_settings(user_id: str, db: AsyncSession) -> Settings:
     return settings
 
 
+def _apply_preset_config_to_settings(settings: Settings, config: dict) -> None:
+    """将预设配置同步到 Settings 主字段。"""
+    settings.api_provider = config['api_provider']
+    settings.api_key = config['api_key']
+    settings.api_base_url = config.get('api_base_url')
+    settings.llm_model = config['llm_model']
+    settings.temperature = config['temperature']
+    settings.max_tokens = config['max_tokens']
+    settings.system_prompt = config.get('system_prompt')
+
+
 @router.get("/presets", response_model=PresetListResponse)
 async def get_presets(
     user: User = Depends(require_login),
@@ -921,6 +932,10 @@ async def update_preset(
         target_preset['description'] = data.description
     if data.config is not None:
         target_preset['config'] = data.config.model_dump()
+
+        # 若更新的是当前激活预设，则同步生效到Settings主字段
+        if target_preset.get('is_active'):
+            _apply_preset_config_to_settings(settings, target_preset['config'])
     
     # 保存回preferences
     prefs['api_presets'] = api_presets
@@ -1005,14 +1020,7 @@ async def activate_preset(
         raise HTTPException(status_code=404, detail="预设不存在")
     
     # 应用配置到Settings主字段
-    config = target_preset['config']
-    settings.api_provider = config['api_provider']
-    settings.api_key = config['api_key']
-    settings.api_base_url = config.get('api_base_url')
-    settings.llm_model = config['llm_model']
-    settings.temperature = config['temperature']
-    settings.max_tokens = config['max_tokens']
-    settings.system_prompt = config.get('system_prompt')
+    _apply_preset_config_to_settings(settings, target_preset['config'])
     
     # 更新所有预设的is_active状态
     for preset in presets:

--- a/backend/app/services/ai_clients/base_client.py
+++ b/backend/app/services/ai_clients/base_client.py
@@ -1,6 +1,7 @@
 """AI 客户端基类"""
 import asyncio
 import hashlib
+import json
 from abc import ABC, abstractmethod
 from typing import Any, AsyncGenerator, Dict, Optional
 
@@ -109,7 +110,14 @@ class BaseAIClient(ABC):
 
                     response = await self.http_client.request(method, url, headers=headers, json=payload)
                     response.raise_for_status()
-                    return response.json()
+                    
+                    try:
+                        return response.json()
+                    except json.JSONDecodeError as e:
+                        logger.error(f"❌ JSON 解析失败: {e}")
+                        logger.error(f"📄 响应状态码: {response.status_code}")
+                        logger.error(f"📄 响应内容: {response.text[:500]}")  # 只记录前500字符
+                        raise ValueError(f"API 返回了非 JSON 响应 (状态码: {response.status_code})")
 
                 except httpx.HTTPStatusError as e:
                     if e.response.status_code in retry_cfg.non_retryable_status_codes:

--- a/backend/app/services/ai_clients/openai_client.py
+++ b/backend/app/services/ai_clients/openai_client.py
@@ -32,9 +32,8 @@ class OpenAIClient(BaseAIClient):
             "messages": messages,
             "temperature": temperature,
             "max_tokens": max_tokens,
+            "stream": stream,
         }
-        if stream:
-            payload["stream"] = True
         if tools:
             # 清理 $schema 字段
             cleaned = []

--- a/backend/app/services/json_helper.py
+++ b/backend/app/services/json_helper.py
@@ -7,6 +7,171 @@ from app.logger import get_logger
 logger = get_logger(__name__)
 
 
+_THINK_START_TAG = "<think>"
+_THINK_END_TAG = "</think>"
+
+
+class NovelContentFilter:
+    """小说正文过滤器：移除思考块与明显元信息（支持流式分块）。"""
+
+    _meta_bracket_pattern = re.compile(r"\[Agent[^\]]*AgentThink[^\]]*\]", re.IGNORECASE)
+    _bullet_pattern = re.compile(r"^(?:[-*•]|\d+[\.)]|[一二三四五六七八九十]+[、\.)])\s+")
+    _meta_bullet_keyword_pattern = re.compile(
+        r"AgentThink|reasoning|analysis|plan\b|step\b"
+        r"|(?:思考|推理|分析|步骤|计划)[：:\-—\s]",
+        re.IGNORECASE,
+    )
+
+    def __init__(self) -> None:
+        self._buffer = ""
+        self._line_buffer = ""
+        self._in_think_block = False
+        self.removed_think_chars = 0
+        self.removed_meta_lines = 0
+
+    def filter_chunk(self, chunk: str) -> str:
+        """过滤一个流式分块，返回可安全展示的正文。"""
+        if not chunk:
+            return ""
+
+        self._buffer += chunk
+        visible = self._extract_visible_content(final=False)
+        return self._filter_meta_lines(visible, final=False)
+
+    def flush(self) -> str:
+        """在流结束时刷新缓冲区，确保尾部正文不丢失。"""
+        visible = self._extract_visible_content(final=True)
+        return self._filter_meta_lines(visible, final=True)
+
+    def clean_text(self, text: str) -> str:
+        """非流式一次性清洗。"""
+        return self.filter_chunk(text) + self.flush()
+
+    def _extract_visible_content(self, final: bool) -> str:
+        output_parts: list[str] = []
+
+        while self._buffer:
+            if self._in_think_block:
+                end_idx = self._buffer.find(_THINK_END_TAG)
+                if end_idx == -1:
+                    if final:
+                        self.removed_think_chars += len(self._buffer)
+                        self._buffer = ""
+                    else:
+                        keep = min(len(self._buffer), len(_THINK_END_TAG) - 1)
+                        removed = len(self._buffer) - keep
+                        if removed > 0:
+                            self.removed_think_chars += removed
+                        self._buffer = self._buffer[-keep:] if keep > 0 else ""
+                    break
+
+                self.removed_think_chars += end_idx + len(_THINK_END_TAG)
+                self._buffer = self._buffer[end_idx + len(_THINK_END_TAG):]
+                self._in_think_block = False
+                continue
+
+            start_idx = self._buffer.find(_THINK_START_TAG)
+            if start_idx == -1:
+                if final:
+                    output_parts.append(self._buffer)
+                    self._buffer = ""
+                else:
+                    keep = min(len(self._buffer), len(_THINK_START_TAG) - 1)
+                    emit_len = len(self._buffer) - keep
+                    if emit_len > 0:
+                        output_parts.append(self._buffer[:emit_len])
+                    self._buffer = self._buffer[-keep:] if keep > 0 else ""
+                break
+
+            if start_idx > 0:
+                output_parts.append(self._buffer[:start_idx])
+
+            self._buffer = self._buffer[start_idx + len(_THINK_START_TAG):]
+            self._in_think_block = True
+
+        return "".join(output_parts)
+
+    def _filter_meta_lines(self, text: str, final: bool) -> str:
+        if not text and not (final and self._line_buffer):
+            return ""
+
+        combined = self._line_buffer + text
+        self._line_buffer = ""
+        filtered_parts: list[str] = []
+
+        for line in combined.splitlines(keepends=True):
+            is_complete_line = line.endswith("\n") or line.endswith("\r")
+            if not is_complete_line and not final:
+                self._line_buffer = line
+                continue
+
+            if self._should_remove_line(line):
+                self.removed_meta_lines += 1
+                continue
+
+            filtered_parts.append(line)
+
+        if final and self._line_buffer:
+            if not self._should_remove_line(self._line_buffer):
+                filtered_parts.append(self._line_buffer)
+            else:
+                self.removed_meta_lines += 1
+            self._line_buffer = ""
+
+        return "".join(filtered_parts)
+
+    def _should_remove_line(self, line: str) -> bool:
+        stripped = line.strip()
+        if not stripped:
+            return False
+
+        if "AgentThink" in stripped:
+            return True
+
+        if self._meta_bracket_pattern.search(stripped):
+            return True
+
+        if stripped.startswith(_THINK_START_TAG) or stripped.startswith(_THINK_END_TAG):
+            return True
+
+        if self._bullet_pattern.match(stripped):
+            if len(stripped) <= 80 and self._meta_bullet_keyword_pattern.search(stripped):
+                return True
+
+        return False
+
+
+def clean_novel_content(text: str) -> str:
+    """清洗小说正文中的思考标签和明显元信息。"""
+    if not text:
+        return text
+
+    content_filter = NovelContentFilter()
+    return content_filter.clean_text(text)
+
+
+def _self_check_novel_content_filter() -> None:
+    """内部自检（可手动调用）：验证典型边界输入。使用显式异常以兼容 python -O。"""
+
+    def _check(actual: str, expected: str, label: str) -> None:
+        if actual != expected:
+            raise AssertionError(f"[{label}] expected {expected!r}, got {actual!r}")
+
+    # 1) 单 chunk：<think>...</think> 后正文必须保留
+    f1 = NovelContentFilter()
+    _check(f1.filter_chunk("<think>先思考</think>正文开始") + f1.flush(), "正文开始", "single-chunk-think")
+
+    # 2) 多 chunk：标签跨分片
+    f2 = NovelContentFilter()
+    parts2 = ["前文<th", "ink>隐藏", "内容</th", "ink>后文"]
+    _check("".join(f2.filter_chunk(part) for part in parts2) + f2.flush(), "前文后文", "cross-chunk-think")
+
+    # 3) 混合元信息：仅移除明显 AgentThink / 规划条目
+    f3 = NovelContentFilter()
+    text3 = "[Agent x AgentThink]\n- 计划：先分析人物\n真正的叙事段落。"
+    _check(f3.clean_text(text3), "真正的叙事段落。", "meta-info-removal")
+
+
 def clean_json_response(text: str) -> str:
     """清洗 AI 返回的 JSON（改进版 - 流式安全）"""
     try:
@@ -22,6 +187,16 @@ def clean_json_response(text: str) -> str:
         text = re.sub(r'^```\s*\n?', '', text, flags=re.MULTILINE)
         text = re.sub(r'\n?```\s*$', '', text, flags=re.MULTILINE)
         text = text.strip()
+        
+        # 移除 <think>...</think> 标签（某些模型会输出思考过程）
+        text = re.sub(r'<think>.*?</think>', '', text, flags=re.DOTALL)
+        
+        # 移除有害控制字符（保留 \t \n \r 等合法空白）
+        text = re.sub(r'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]', '', text)
+        text = text.strip()
+        
+        # 仅记录长度，避免在 info/error 输出敏感文本
+        logger.debug(f"📄 清洗后的JSON长度: {len(text)}")
         
         if len(text) != original_length:
             logger.debug(f"   移除markdown后长度: {len(text)}")
@@ -43,7 +218,7 @@ def clean_json_response(text: str) -> str:
         
         if start == -1:
             logger.warning(f"⚠️ 未找到JSON起始符号 {{ 或 [")
-            logger.debug(f"   文本预览: {text[:200]}")
+            logger.debug("   未找到 JSON 起始符号，返回原文本")
             return text
         
         if start > 0:
@@ -135,15 +310,13 @@ def clean_json_response(text: str) -> str:
             logger.debug(f"✅ 清洗后JSON验证成功")
         except json.JSONDecodeError as e:
             logger.error(f"❌ 清洗后JSON仍然无效: {e}")
-            logger.debug(f"   结果预览: {result[:500]}")
-            logger.debug(f"   结果结尾: ...{result[-200:]}")
+            logger.debug(f"   结果长度: {len(result)}")
         
         return result
         
     except Exception as e:
         logger.error(f"❌ clean_json_response 出错: {e}")
         logger.error(f"   文本长度: {len(text) if text else 0}")
-        logger.error(f"   文本预览: {text[:200] if text else 'None'}")
         raise
 
 
@@ -155,5 +328,4 @@ def parse_json(text: str) -> Union[Dict, List]:
     except Exception as e:
         logger.error(f"❌ parse_json 出错: {e}")
         logger.error(f"   原始文本长度: {len(text) if text else 0}")
-        logger.error(f"   清洗后文本长度: {len(cleaned) if cleaned else 0}")
         raise

--- a/frontend/src/components/AppFooter.tsx
+++ b/frontend/src/components/AppFooter.tsx
@@ -1,19 +1,18 @@
-import { useState, useEffect } from 'react';
-import { Typography, Space, Divider, Badge, Button, Grid } from 'antd';
-import { GithubOutlined, CopyrightOutlined, HeartFilled, ClockCircleOutlined, GiftOutlined } from '@ant-design/icons';
+import { ClockCircleOutlined, CopyrightOutlined, GiftOutlined, GithubOutlined, HeartFilled } from '@ant-design/icons';
+import { Badge, Button, Divider, Space, Typography } from 'antd';
+import { useEffect, useState } from 'react';
 import { VERSION_INFO, getVersionString } from '../config/version';
+import { useViewport } from '../hooks/useViewport';
 import { checkLatestVersion } from '../services/versionService';
 
 const { Text, Link } = Typography;
-const { useBreakpoint } = Grid;
 
 interface AppFooterProps {
   sidebarWidth?: number;
 }
 
 export default function AppFooter({ sidebarWidth = 0 }: AppFooterProps) {
-  const screens = useBreakpoint();
-  const isMobile = !screens.md;
+  const { isDesktop, isMobile } = useViewport();
   const [hasUpdate, setHasUpdate] = useState(false);
   const [latestVersion, setLatestVersion] = useState('');
   const [releaseUrl, setReleaseUrl] = useState('');
@@ -44,7 +43,7 @@ export default function AppFooter({ sidebarWidth = 0 }: AppFooterProps) {
   };
 
   // 计算左边距：桌面端有侧边栏时需要偏移
-  const leftOffset = isMobile ? 0 : sidebarWidth;
+  const leftOffset = isDesktop ? sidebarWidth : 0;
 
   return (
     <div

--- a/frontend/src/components/ChangelogFloatingButton.tsx
+++ b/frontend/src/components/ChangelogFloatingButton.tsx
@@ -1,14 +1,17 @@
 import { useState } from 'react';
-import { FloatButton, Grid } from 'antd';
+import { FloatButton } from 'antd';
 import { FileTextOutlined } from '@ant-design/icons';
 import ChangelogModal from './ChangelogModal';
-
-const { useBreakpoint } = Grid;
+import { useViewport } from '../hooks/useViewport';
 
 export default function ChangelogFloatingButton() {
   const [showChangelog, setShowChangelog] = useState(false);
-  const screens = useBreakpoint();
-  const isMobile = !screens.md;
+  const { isMobile } = useViewport();
+
+  // 移动端不显示悬浮按钮，避免遮挡主内容与底部操作区域
+  if (isMobile) {
+    return null;
+  }
 
   return (
     <>
@@ -17,14 +20,10 @@ export default function ChangelogFloatingButton() {
         type="primary"
         tooltip="查看更新日志"
         style={{
-          // 桌面端时，确保按钮在主内容区域内（侧边栏右侧）
           right: 24,
           bottom: 100,
-          // 移动端无侧边栏，不需要额外处理
-          ...(isMobile ? {} : {
-            // 确保 zIndex 低于侧边栏但高于内容
-            zIndex: 999,
-          }),
+          // 确保 zIndex 低于侧边栏但高于内容
+          zIndex: 999,
         }}
         onClick={() => setShowChangelog(true)}
       />

--- a/frontend/src/components/SpringFestival.tsx
+++ b/frontend/src/components/SpringFestival.tsx
@@ -72,8 +72,16 @@ function loadBtnPosition(): BtnPosition {
   return getDefaultBtnPosition();
 }
 
+function readEnabled(): boolean {
+  const saved = localStorage.getItem('spring-festival-enabled');
+  return saved === null ? true : saved === 'true';
+}
+
 export default function SpringFestival() {
+  const [enabled, setEnabled] = useState(readEnabled);
+
   const [visible, setVisible] = useState(() => {
+    if (!readEnabled()) return false;
     const saved = localStorage.getItem('spring-festival-visible');
     if (saved !== null) return saved === 'true';
     return isSpringFestivalSeason();
@@ -104,6 +112,48 @@ export default function SpringFestival() {
   const [hasDragged, setHasDragged] = useState(false);
   const dragStartRef = useRef<{ startX: number; startY: number; startBtnX: number; startBtnY: number } | null>(null);
   const btnRef = useRef<HTMLButtonElement>(null);
+
+  // 监听外部开关（例如用户菜单中的开关）
+  useEffect(() => {
+    const handleExternalToggle = (event: Event) => {
+      const customEvent = event as CustomEvent<boolean>;
+      const nextEnabled = Boolean(customEvent.detail);
+      setEnabled(nextEnabled);
+      localStorage.setItem('spring-festival-enabled', String(nextEnabled));
+
+      if (nextEnabled) {
+        const savedVisible = localStorage.getItem('spring-festival-visible');
+        const nextVisible = savedVisible !== null ? savedVisible === 'true' : true;
+        setVisible(nextVisible);
+        setShowBanner(true);
+      } else {
+        setVisible(false);
+      }
+    };
+
+    const handleStorageChange = (event: StorageEvent) => {
+      if (event.key === 'spring-festival-enabled' && event.newValue !== null) {
+        const nextEnabled = event.newValue === 'true';
+        setEnabled(nextEnabled);
+        if (!nextEnabled) {
+          setVisible(false);
+        } else {
+          const savedVisible = localStorage.getItem('spring-festival-visible');
+          const nextVisible = savedVisible !== null ? savedVisible === 'true' : true;
+          setVisible(nextVisible);
+          setShowBanner(true);
+        }
+      }
+    };
+
+    window.addEventListener('spring-festival-toggle', handleExternalToggle as EventListener);
+    window.addEventListener('storage', handleStorageChange);
+
+    return () => {
+      window.removeEventListener('spring-festival-toggle', handleExternalToggle as EventListener);
+      window.removeEventListener('storage', handleStorageChange);
+    };
+  }, []);
 
   // 生成飘落物
   const createFallingItem = useCallback((): FallingItem => {
@@ -416,6 +466,7 @@ export default function SpringFestival() {
 
   // 切换显示状态（只有未拖动时才触发）
   const handleBtnClick = () => {
+    if (!enabled) return;
     if (hasDragged) return; // 拖动过就不触发点击
     const next = !visible;
     setVisible(next);
@@ -435,6 +486,10 @@ export default function SpringFestival() {
     touchAction: 'none',
     userSelect: 'none',
   };
+
+  if (!enabled) {
+    return null;
+  }
 
   return (
     <>

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
-import { Dropdown, Avatar, Space, Typography, message, Modal, Form, Input, Button } from 'antd';
-import { UserOutlined, LogoutOutlined, TeamOutlined, CrownOutlined, LockOutlined } from '@ant-design/icons';
+import { Dropdown, Avatar, Space, Typography, message, Modal, Form, Input, Button, Switch } from 'antd';
+import { UserOutlined, LogoutOutlined, TeamOutlined, CrownOutlined, LockOutlined, GiftOutlined } from '@ant-design/icons';
 import { authApi } from '../services/api';
 import type { User } from '../types';
 import type { MenuProps } from 'antd';
@@ -19,6 +19,10 @@ export default function UserMenu({ showFullInfo = false }: UserMenuProps) {
   const [showChangePassword, setShowChangePassword] = useState(false);
   const [changePasswordForm] = Form.useForm();
   const [changingPassword, setChangingPassword] = useState(false);
+  const [springFestivalEnabled, setSpringFestivalEnabled] = useState<boolean>(() => {
+    const saved = localStorage.getItem('spring-festival-enabled');
+    return saved === null ? true : saved === 'true';
+  });
 
   useEffect(() => {
     loadCurrentUser();
@@ -68,6 +72,13 @@ export default function UserMenu({ showFullInfo = false }: UserMenuProps) {
     }
   };
 
+  const handleToggleSpringFestival = (enabled: boolean) => {
+    setSpringFestivalEnabled(enabled);
+    localStorage.setItem('spring-festival-enabled', String(enabled));
+    window.dispatchEvent(new CustomEvent('spring-festival-toggle', { detail: enabled }));
+    message.success(enabled ? '已开启新年特效' : '已关闭新年特效');
+  };
+
   const menuItems: MenuProps['items'] = [
     {
       key: 'user-info',
@@ -107,6 +118,23 @@ export default function UserMenu({ showFullInfo = false }: UserMenuProps) {
       type: 'divider',
     },
     {
+      key: 'spring-festival-toggle',
+      icon: <GiftOutlined />,
+      label: '新年特效',
+      extra: (
+        <Switch
+          size="small"
+          checked={springFestivalEnabled}
+          onClick={(_checked, e) => e?.stopPropagation()}
+          onChange={handleToggleSpringFestival}
+        />
+      ),
+      onClick: ({ domEvent }) => domEvent.stopPropagation(),
+    },
+    {
+      type: 'divider',
+    },
+    {
       key: 'logout',
       icon: <LogoutOutlined />,
       label: '退出登录',
@@ -120,7 +148,7 @@ export default function UserMenu({ showFullInfo = false }: UserMenuProps) {
 
   return (
     <>
-      <Dropdown menu={{ items: menuItems }} placement="bottomRight">
+      <Dropdown menu={{ items: menuItems }} placement={showFullInfo ? 'topLeft' : 'bottomRight'}>
         <div
           style={{
             cursor: 'pointer',

--- a/frontend/src/hooks/useViewport.ts
+++ b/frontend/src/hooks/useViewport.ts
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react';
+
+export type ViewportMode = 'desktop' | 'mobile-portrait' | 'mobile-landscape';
+
+export const DESKTOP_BREAKPOINT = 1024;
+
+function getViewportMode(width: number, height: number): ViewportMode {
+  if (width >= DESKTOP_BREAKPOINT) return 'desktop';
+  return height >= width ? 'mobile-portrait' : 'mobile-landscape';
+}
+
+export interface ViewportInfo {
+  width: number;
+  height: number;
+  mode: ViewportMode;
+  isDesktop: boolean;
+  isMobile: boolean;
+  isMobilePortrait: boolean;
+  isMobileLandscape: boolean;
+}
+
+export function useViewport(): ViewportInfo {
+  const [state, setState] = useState(() => {
+    const w = window.innerWidth;
+    const h = window.innerHeight;
+    return { width: w, height: h, mode: getViewportMode(w, h) };
+  });
+
+  useEffect(() => {
+    let rafId = 0;
+
+    const update = () => {
+      if (rafId) cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(() => {
+        const w = window.innerWidth;
+        const h = window.innerHeight;
+        setState({ width: w, height: h, mode: getViewportMode(w, h) });
+      });
+    };
+
+    window.addEventListener('resize', update);
+    window.addEventListener('orientationchange', update);
+
+    return () => {
+      if (rafId) cancelAnimationFrame(rafId);
+      window.removeEventListener('resize', update);
+      window.removeEventListener('orientationchange', update);
+    };
+  }, []);
+
+  const isDesktop = state.mode === 'desktop';
+
+  return {
+    width: state.width,
+    height: state.height,
+    mode: state.mode,
+    isDesktop,
+    isMobile: !isDesktop,
+    isMobilePortrait: state.mode === 'mobile-portrait',
+    isMobileLandscape: state.mode === 'mobile-landscape',
+  };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -123,8 +123,8 @@ body {
     height: 4px;
   }
 
-  /* 移动端优化触摸区域 */
-  button,
+  /* 移动端优化触摸区域（排除 Switch 等小型控件） */
+  button:not([role="switch"]),
   a,
   [role="button"] {
     min-height: 44px;

--- a/frontend/src/pages/ProjectList.tsx
+++ b/frontend/src/pages/ProjectList.tsx
@@ -1,19 +1,20 @@
-import { useEffect, useState, useRef, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { Card, Button, Modal, message, Spin, Space, Tag, Progress, Typography, Alert, Upload, Checkbox, Tooltip, Drawer, Menu } from 'antd';
-import { EditOutlined, DeleteOutlined, BookOutlined, RocketOutlined, CalendarOutlined, FileTextOutlined, TrophyOutlined, SettingOutlined, UploadOutlined, DownloadOutlined, ApiOutlined, BulbOutlined, LoadingOutlined, FileSearchOutlined, MenuUnfoldOutlined, CloseOutlined } from '@ant-design/icons';
-import { projectApi } from '../services/api';
-import { useStore } from '../store';
-import { useProjectSync } from '../store/hooks';
-import { eventBus, EventNames } from '../store/eventBus';
+import { ApiOutlined, BookOutlined, BulbOutlined, CalendarOutlined, CloseOutlined, DeleteOutlined, DownloadOutlined, EditOutlined, FileSearchOutlined, FileTextOutlined, LoadingOutlined, MenuUnfoldOutlined, RocketOutlined, SettingOutlined, TrophyOutlined, UploadOutlined } from '@ant-design/icons';
+import { Alert, Button, Card, Checkbox, Drawer, Menu, message, Modal, Progress, Space, Spin, Tag, Tooltip, Typography, Upload } from 'antd';
 import type { ReactNode } from 'react';
-import { cardStyles, cardHoverHandlers } from '../components/CardStyles';
-import UserMenu from '../components/UserMenu';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { cardHoverHandlers, cardStyles } from '../components/CardStyles';
 import ChangelogFloatingButton from '../components/ChangelogFloatingButton';
-import SettingsPage from './Settings';
+import UserMenu from '../components/UserMenu';
+import { projectApi } from '../services/api';
+import { useViewport } from '../hooks/useViewport';
+import { useStore } from '../store';
+import { eventBus, EventNames } from '../store/eventBus';
+import { useProjectSync } from '../store/hooks';
+import BookImport from './BookImport';
 import MCPPluginsPage from './MCPPlugins';
 import PromptTemplates from './PromptTemplates';
-import BookImport from './BookImport';
+import SettingsPage from './Settings';
 
 const { Title, Text, Paragraph } = Typography;
 
@@ -62,6 +63,7 @@ export default function ProjectList() {
   const { refreshProjects, deleteProject } = useProjectSync();
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const { isDesktop, isMobile, isMobilePortrait, isMobileLandscape } = useViewport();
 
   // 处理切换到 MCP 视图的事件
   const handleSwitchToMcp = useCallback(() => {
@@ -314,24 +316,23 @@ export default function ProjectList() {
     }
   };
 
-  const isMobile = window.innerWidth <= 768;
 
   return (
     <div style={{
-      height: '100vh',
       display: 'flex',
       flexDirection: 'row', // 改为行布局，容纳侧边栏
       background: 'var(--color-bg-base)',
-      overflow: 'hidden'
+      overflow: 'hidden',
+      height: isMobile ? '100dvh' : '100vh'
     }}>
       {contextHolder}
 
       {/* 侧边栏 - 仅桌面端显示 - 样式对齐 ProjectDetail */}
-      {!isMobile && (
+      {isDesktop && (
         <div style={{
           width: 220, // 对齐 ProjectDetail 的宽度
           background: '#fff',
-          borderRight: '1px solid rgba(0,0,0,0.06)',
+          borderRight: 'none',
           display: 'flex',
           flexDirection: 'column',
           zIndex: 10,
@@ -499,7 +500,7 @@ export default function ProjectList() {
 
           {/* 底部用户信息 */}
           <div style={{ padding: 16, borderTop: '1px solid rgba(0,0,0,0.06)' }}>
-             <UserMenu />
+             <UserMenu showFullInfo />
           </div>
         </div>
       )}
@@ -511,7 +512,7 @@ export default function ProjectList() {
         flexDirection: 'column',
         height: '100%',
         overflow: 'hidden',
-        marginLeft: isMobile ? 0 : 220 // 为固定定位的侧边栏留出空间
+        marginLeft: isDesktop ? 220 : 0 // 为固定定位的侧边栏留出空间
       }}>
       
         {/* 移动端顶部导航栏 */}
@@ -520,8 +521,9 @@ export default function ProjectList() {
             flexShrink: 0,
             background: 'var(--color-primary)',
             boxShadow: 'var(--shadow-header)',
-            height: 56,
-            padding: '0 12px',
+            height: isMobileLandscape ? 48 : 56,
+            padding: isMobileLandscape ? '0 10px' : '0 12px',
+            paddingTop: 'env(safe-area-inset-top, 0px)',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'space-between',
@@ -533,31 +535,31 @@ export default function ProjectList() {
                   icon={<MenuUnfoldOutlined />}
                   onClick={() => setDrawerVisible(true)}
                   style={{
-                    fontSize: 18,
+                    fontSize: isMobileLandscape ? 16 : 18,
                     color: '#fff',
-                    width: 36,
-                    height: 36
+                    width: isMobileLandscape ? 32 : 36,
+                    height: isMobileLandscape ? 32 : 36
                   }}
                 />
              </div>
              
-             <span style={{
-               color: '#fff',
-               fontWeight: 600,
-               fontSize: 16,
-               flex: 1,
-               textAlign: 'center',
-               overflow: 'hidden',
-               textOverflow: 'ellipsis',
-               whiteSpace: 'nowrap',
-               paddingRight: 36  // 为了与左侧菜单按钮对称
-             }}>
-               {activeView === 'projects' ? '我的书架' :
-                activeView === 'prompts' ? '提示词模板' :
-                activeView === 'book-import' ? '拆书导入' :
-                activeView === 'mcp' ? 'MCP 插件' : 'API 设置'}
-             </span>
-          </div>
+              <span style={{
+                color: '#fff',
+                fontWeight: 600,
+                fontSize: isMobileLandscape ? 14 : 16,
+                flex: 1,
+                textAlign: 'center',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                paddingRight: 36  // 为了与左侧菜单按钮对称
+              }}>
+                {activeView === 'projects' ? '我的书架' :
+                 activeView === 'prompts' ? '提示词模板' :
+                 activeView === 'book-import' ? '拆书导入' :
+                 activeView === 'mcp' ? 'MCP 插件' : 'API 设置'}
+              </span>
+           </div>
         )}
 
         {/* 移动端侧边栏 Drawer */}
@@ -578,7 +580,7 @@ export default function ProjectList() {
                 }}>
                   <BookOutlined />
                 </div>
-                <span style={{ fontWeight: 600, fontSize: 16 }}>MuMuAINovel</span>
+               <span style={{ fontWeight: 600, fontSize: isMobileLandscape ? 14 : 16 }}>MuMuAINovel</span>
               </div>
             }
             closeIcon={null}
@@ -593,7 +595,7 @@ export default function ProjectList() {
             placement="left"
             onClose={() => setDrawerVisible(false)}
             open={drawerVisible}
-            width="60%"
+            width={isMobilePortrait ? '82%' : '56%'}
             styles={{ body: { padding: 0, display: 'flex', flexDirection: 'column' } }}
           >
             <div style={{ flex: 1, overflowY: 'auto' }}>
@@ -682,7 +684,7 @@ export default function ProjectList() {
         )}
 
         {/* 桌面端顶部标题栏 */}
-        {!isMobile && (
+        {isDesktop && (
           <div style={{
              height: 70, // 与 ProjectDetail header 高度一致
              padding: '0 24px',
@@ -775,7 +777,7 @@ export default function ProjectList() {
             flex: 1,
             overflowY: 'auto',
             padding: (activeView === 'projects' || activeView === 'book-import')
-              ? `${isMobile ? 16 : 24}px ${isMobile ? 16 : 32}px`
+              ? `${isMobile ? (isMobilePortrait ? 16 : 12) : 24}px ${isMobile ? (isMobilePortrait ? 16 : 14) : 32}px`
               : 0,
             background: 'var(--color-bg-base)',
           }}
@@ -831,19 +833,19 @@ export default function ProjectList() {
             <Spin spinning={loading}>
               <div style={{
                 ...cardStyles.bookshelf,
-                // 移动端显示一列
+                // 移动端竖屏一列，横屏双列
                 ...(isMobile && {
-                  gridTemplateColumns: '1fr',
-                  gap: '16px',
-                  padding: '16px 0',
+                  gridTemplateColumns: isMobilePortrait ? '1fr' : 'repeat(2, minmax(0, 1fr))',
+                  gap: isMobilePortrait ? '16px' : '12px',
+                  padding: isMobilePortrait ? '16px 0' : '12px 0',
                 })
               }}>
                 {/* 新建/灵感卡片 */}
-                <div style={{ position: 'relative', width: '100%', minWidth: 0, minHeight: isMobile ? 300 : 330 }}>
+                <div style={{ position: 'relative', width: '100%', minWidth: 0, minHeight: isMobile ? (isMobilePortrait ? 300 : 250) : 330 }}>
                   <Card
                     hoverable
-                    style={{ ...cardStyles.newProjectBook, minHeight: isMobile ? 300 : 330 }}
-                    styles={{ body: { padding: isMobile ? '16px' : '24px', flex: 1, display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center' } }}
+                    style={{ ...cardStyles.newProjectBook, minHeight: isMobile ? (isMobilePortrait ? 300 : 250) : 330 }}
+                    styles={{ body: { padding: isMobile ? (isMobilePortrait ? '16px' : '12px') : '24px', flex: 1, display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center' } }}
                     {...cardHoverHandlers}
                     data-type="new-project"
                   >
@@ -1138,7 +1140,7 @@ export default function ProjectList() {
         confirmLoading={importing}
         okText="导入"
         cancelText="取消"
-        width={isMobile ? '90%' : 500}
+        width={isMobile ? (isMobilePortrait ? '90%' : '72%') : 500}
         centered
         okButtonProps={{ disabled: !validationResult?.valid }}
       >
@@ -1232,7 +1234,7 @@ export default function ProjectList() {
         confirmLoading={exporting}
         okText={selectedProjectIds.length > 0 ? `导出 (${selectedProjectIds.length})` : '导出'}
         cancelText="取消"
-        width={isMobile ? '90%' : 700}
+        width={isMobile ? (isMobilePortrait ? '90%' : '82%') : 700}
         centered
         okButtonProps={{ disabled: selectedProjectIds.length === 0 }}
       >

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -512,6 +512,11 @@ export default function SettingsPage() {
           config,
         });
         message.success('预设已更新');
+
+        // 若编辑的是激活预设，更新后立即刷新当前配置，保持UI与服务端一致
+        if (editingPreset.id === activePresetId) {
+          loadSettings();
+        }
       } else {
         const request: PresetCreateRequest = {
           name: values.name,
@@ -1120,11 +1125,6 @@ export default function SettingsPage() {
                               dropdownRender={(menu) => (
                                 <>
                                   {menu}
-                                  {fetchingModels && (
-                                    <div style={{ padding: '8px 12px', color: 'var(--color-text-secondary)', textAlign: 'center', fontSize: isMobile ? '12px' : '14px' }}>
-                                      <Spin size="small" /> 正在获取模型列表...
-                                    </div>
-                                  )}
                                   {!fetchingModels && modelOptions.length === 0 && modelsFetched && !modelSearchText && (
                                     <div style={{ padding: '8px 12px', color: '#ff4d4f', textAlign: 'center', fontSize: isMobile ? '12px' : '14px' }}>
                                       未能获取到模型列表，可直接输入模型名称
@@ -1137,13 +1137,7 @@ export default function SettingsPage() {
                                   )}
                                 </>
                               )}
-                              notFoundContent={
-                                fetchingModels ? (
-                                  <div style={{ padding: '8px 12px', textAlign: 'center', fontSize: isMobile ? '12px' : '14px' }}>
-                                    <Spin size="small" /> 加载中...
-                                  </div>
-                                ) : null
-                              }
+                              notFoundContent={fetchingModels ? <Space><Spin size="small" />正在获取模型列表...</Space> : null}
                               suffixIcon={
                                 !isMobile ? (
                                   <div
@@ -1636,11 +1630,6 @@ export default function SettingsPage() {
                     dropdownRender={(menu) => (
                       <>
                         {menu}
-                        {fetchingPresetModels && (
-                          <div style={{ padding: '8px 12px', color: 'var(--color-text-secondary)', textAlign: 'center', fontSize: '12px' }}>
-                            <Spin size="small" /> 正在获取模型列表...
-                          </div>
-                        )}
                         {!fetchingPresetModels && presetModelOptions.length === 0 && presetModelsFetched && !presetModelSearchText && (
                           <div style={{ padding: '8px 12px', color: '#ff4d4f', textAlign: 'center', fontSize: '12px' }}>
                             未能获取到模型列表，可直接输入模型名称
@@ -1653,13 +1642,7 @@ export default function SettingsPage() {
                         )}
                       </>
                     )}
-                    notFoundContent={
-                      fetchingPresetModels ? (
-                        <div style={{ padding: '8px 12px', textAlign: 'center', fontSize: '12px' }}>
-                          <Spin size="small" /> 加载中...
-                        </div>
-                      ) : null
-                    }
+                    notFoundContent={fetchingPresetModels ? <Space><Spin size="small" />正在获取模型列表...</Space> : null}
                     suffixIcon={
                       <div
                         onClick={(e) => {


### PR DESCRIPTION
本次改动聚焦以下问题：

1. API 预设保存后与当前生效配置不同步（需重复“激活”）。
2. 首页在不同宽高比/横竖屏下布局一致性不足。
3. 移动端菜单与底栏在部分断点下显示异常。
4. 新年特效开关语义不完整（无法完全禁用相关功能）。
5. AI 生成链路中存在思考标签/非标准响应污染显示内容。

## 主要改动

### 一、设置与配置同步（Settings）

- 修复“保存已激活预设后，当前配置不立即同步”的问题。
- 后端在保存当前激活预设时同步更新当前生效配置字段。
- 前端保存后补充状态刷新，避免界面与实际配置不一致。

### 二、首页响应式与布局（ProjectList / AppFooter）

- 按桌面优先策略优化宽高比与横竖屏适配。
- 修复侧栏收起场景下底栏宽度/偏移不一致问题。
- 调整移动端顶部与抽屉交互，减少拥挤与遮挡。
- 移除影响主内容阅读的移动端悬浮入口（桌面保留）。

### 三、用户菜单与新年特效控制（UserMenu / SpringFestival / index.css）

- 在用户菜单中新增“新年特效”总开关（持久化）。
- 关闭时禁用整个新年特效能力（相关入口与效果不渲染）。
- 修复菜单项样式一致性（分割线、行高、对齐）。
- 修复全局触控样式误伤 `Switch` 导致拉伸变形的问题。

### 四、AI 生成链路稳定性（backend）

- 增强非 JSON 响应处理与错误可观测性。
- 过滤流式输出中的思考标签与元信息噪声（如 `<think>`）。
- 优化章节生成/保存流程中的边界处理，减少中断场景异常。

## 影响范围

### 前端

- `frontend/src/pages/ProjectList.tsx`
- `frontend/src/pages/Settings.tsx`
- `frontend/src/components/AppFooter.tsx`
- `frontend/src/components/ChangelogFloatingButton.tsx`
- `frontend/src/components/UserMenu.tsx`
- `frontend/src/components/SpringFestival.tsx`
- `frontend/src/index.css`

### 后端

- `backend/app/api/settings.py`
- `backend/app/api/chapters.py`
- `backend/app/services/ai_clients/base_client.py`
- `backend/app/services/ai_clients/openai_client.py`
- `backend/app/services/json_helper.py`

## 验证情况

- 前端：`npm run lint` 通过。
- 手测通过：
  - 预设保存后当前配置即时同步。
  - 首页在桌面/移动端横竖屏下布局稳定。
  - 用户菜单“新年特效”开关即时生效且刷新后保持。
  - 生成内容不再混入思考标签等噪声文本。

## 风险与回归关注

- 设置预设相关接口联动（保存/激活/读取）需重点回归。
- 移动端全局样式调整可能影响其他交互组件触控尺寸。
- 生成链路文本过滤策略需关注极端输出格式兼容性。
