### PR TITLE
fix: 使用axonhub中转时，llm请求失败

### DIFF
--- a/backend/app/services/ai_clients/gemini_client.py
+++ b/backend/app/services/ai_clients/gemini_client.py
@@ -144,10 +144,10 @@ class GeminiClient:
                 response.raise_for_status()
                 try:
                     async for line in response.aiter_lines():
-                        if line.startswith("data: "):
+                        if line.startswith("data:"):
                             import json
                             try:
-                                data = json.loads(line[6:])
+                                data = json.loads(line[5:].lstrip())
                                 candidates = data.get("candidates", [])
                                 if candidates and len(candidates) > 0:
                                     parts = candidates[0].get("content", {}).get("parts", [])

--- a/backend/app/services/ai_clients/openai_client.py
+++ b/backend/app/services/ai_clients/openai_client.py
@@ -107,8 +107,8 @@ class OpenAIClient(BaseAIClient):
                 response.raise_for_status()
                 try:
                     async for line in response.aiter_lines():
-                        if line.startswith("data: "):
-                            data_str = line[6:]
+                        if line.startswith("data:"):
+                            data_str = line[5:].lstrip()
                             if data_str.strip() == "[DONE]":
                                 # 流结束，检查是否有工具调用需要处理
                                 if tool_calls_buffer:


### PR DESCRIPTION
axonhub中转后，sse数据流开头为"data:", 缺少空格。