### PR TITLE
fix: 1-N模式大纲提取修复

### DIFF
--- a/backend/app/services/chapter_context_service.py
+++ b/backend/app/services/chapter_context_service.py
@@ -289,7 +289,8 @@ class OneToManyContextBuilder:
         if chapter.expansion_plan:
             try:
                 plan = json.loads(chapter.expansion_plan)
-                outline_content = f"""剧情摘要：{plan.get('plot_summary', '无')}
+                # expansion_plan没有plot_summary这个键，
+                outline_content = f"""剧情摘要：{plan.get('plot_summary') or chapter.summary or '无'}
 
 关键事件：
 {chr(10).join(f'- {event}' for event in plan.get('key_events', []))}


### PR DESCRIPTION
API测试发现expansion_plan没有 plot_summary这个键。

替换掉原本的分章节概要，重新生成的文章内容也完全不变，这段完全失效了。每次提供的都只有分章节的关键事件部分和上级大纲。plot_summary是在上级大纲的outline里，对应就是chapter.summary，如果本身意图就是这样的话。