### PR TITLE
Fix content and summary handling in book import service

### DIFF
--- a/backend/app/services/book_import_service.py
+++ b/backend/app/services/book_import_service.py
@@ -1205,7 +1205,7 @@ class BookImportService:
         fallback_outlines = [
             BookImportOutline(
                 title=chapter.title,
-                content=(chapter.summary or self._build_summary(chapter.content or "")),
+                content=str(chapter.summary or self._build_summary(chapter.content or "") or "").strip(),
                 order_index=chapter.chapter_number,
                 structure=self._build_fallback_outline_structure(chapter),
             )
@@ -1378,7 +1378,7 @@ class BookImportService:
         }
 
     def _build_fallback_outline_structure(self, chapter: BookImportChapter) -> dict[str, Any]:
-        summary = (chapter.summary or self._build_summary(chapter.content or "")).strip()
+        summary = str(chapter.summary or self._build_summary(chapter.content or "") or "").strip()
         if not summary:
             summary = "本章围绕主要人物与核心冲突推进剧情。"
 


### PR DESCRIPTION
'NoneType' object has no attribute 'strip'问题

🐛 报错的精准位置与成因
报错发生在 book_import_service.py 文件的第 811 行，位于 _build_fallback_outline_structure 方法中：

Python
def _build_fallback_outline_structure(self, chapter: BookImportChapter) -> dict[str, Any]:
    # 就是下面这一行！
    summary = (chapter.summary or self._build_summary(chapter.content or "")).strip()
    ...
触发崩溃的逻辑链条如下：

空正文出现：假设你的 TXT 文件中解析出了一个“只有章节标题，没有正文内容”的章节（此时 chapter.content 为空字符串 ""，chapter.summary 为 None）。

生成摘要返回 None：代码尝试调用 self._build_summary("") 来生成摘要。而在代码第 1391 行的 _build_summary 方法定义中，如果传入的内容为空，它会直接返回 None。

致命的空值计算：此时括号内的表达式变成了 (None or None)，结果依然是 None。

报错抛出：紧接着，代码对这个结果执行了 .strip()，也就是 None.strip()，导致程序当场崩溃。

📝 为什么你的 TXT 会触发这个 Bug？
只要你的 TXT 文件中存在**“空章节”**，就会踩中这个坑。通常是以下三种排版情况之一引起的：

连续的章节标题：比如作者写废了一章或者为了占位，直接连着写：

Plaintext
第一章 命运相遇
第二章 意料之外 (注意：第一章和第二章之间没有任何正文)
这里是第二章的正文...
文件末尾的孤立标题：在 TXT 文件的最后一行，刚好是一个章节标题，下面没有跟着任何正文。

被误判的弱标题：根据之前 txt_parser_service.py 的“弱匹配”逻辑，如果你的正文里刚好有一句很短的无标点短句，且前后都是空行，它被误认成了章节标题，而它下面紧接着又是一个真正的章节标题，就会产生一个被夹在中间的“空章节”。