### PR TITLE
fix: 兼容非标准 SSE 格式的流式响应

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -67,11 +67,7 @@ CORS_ORIGINS=["http://localhost:8000","http://127.0.0.1:8000"]
 
 # Gemini 配置
 # GEMINI_API_KEY=your_gemini_api_key_here
-# GEMINI_BASE_URL=https://generativelanguage.googleapis.com
-
-# Anthropic 配置
-# ANTHROPIC_API_KEY=your_anthropic_api_key_here
-# ANTHROPIC_BASE_URL=https://api.anthropic.com
+# GEMINI_BASE_URL=https://generativelanguage.googleapis.com/v1beta
 
 # 默认 AI 配置
 DEFAULT_AI_PROVIDER=openai

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -55,12 +55,23 @@ CORS_ORIGINS=["http://localhost:8000","http://127.0.0.1:8000"]
 # NO_PROXY=localhost,127.0.0.1
 
 # ==========================================
-# AI 服务配置（至少配置一个）
+# AI 服务配置（可选 - 推荐在网页配置）
 # ==========================================
+# 说明：API Key 推荐在网页的「设置」页面配置，会保存到数据库
+# 以下配置仅作为新用户的默认值，首次使用后失效
+# 如需预设默认值，取消注释并填写：
 
 # OpenAI 配置
-OPENAI_API_KEY=your_openai_api_key_here
-OPENAI_BASE_URL=https://api.openai.com/v1
+# OPENAI_API_KEY=your_openai_api_key_here
+# OPENAI_BASE_URL=https://api.openai.com/v1
+
+# Gemini 配置
+# GEMINI_API_KEY=your_gemini_api_key_here
+# GEMINI_BASE_URL=https://generativelanguage.googleapis.com
+
+# Anthropic 配置
+# ANTHROPIC_API_KEY=your_anthropic_api_key_here
+# ANTHROPIC_BASE_URL=https://api.anthropic.com
 
 # 默认 AI 配置
 DEFAULT_AI_PROVIDER=openai

--- a/backend/app/api/settings.py
+++ b/backend/app/api/settings.py
@@ -38,11 +38,24 @@ class CoverSettingsTestRequest(BaseModel):
 
 
 def read_env_defaults() -> Dict[str, Any]:
-    """从.env文件读取默认配置（仅读取，不修改）"""
+    """从.env文件读取默认配置（仅读取，不修改）
+    
+    根据 DEFAULT_AI_PROVIDER 返回对应的 API Key 和 Base URL
+    """
+    provider = app_settings.default_ai_provider
+    
+    # 根据提供商选择对应的配置
+    if provider == "gemini":
+        api_key = app_settings.gemini_api_key or ""
+        api_base_url = app_settings.gemini_base_url or ""
+    else:  # openai (默认)
+        api_key = app_settings.openai_api_key or ""
+        api_base_url = app_settings.openai_base_url or ""
+    
     return {
-        "api_provider": app_settings.default_ai_provider,
-        "api_key": app_settings.openai_api_key or app_settings.anthropic_api_key or "",
-        "api_base_url": app_settings.openai_base_url or app_settings.anthropic_base_url or "",
+        "api_provider": provider,
+        "api_key": api_key,
+        "api_base_url": api_base_url,
         "llm_model": app_settings.default_model,
         "temperature": app_settings.default_temperature,
         "max_tokens": app_settings.default_max_tokens,

--- a/backend/app/services/ai_clients/openai_client.py
+++ b/backend/app/services/ai_clients/openai_client.py
@@ -107,8 +107,9 @@ class OpenAIClient(BaseAIClient):
                 response.raise_for_status()
                 try:
                     async for line in response.aiter_lines():
-                        if line.startswith("data: "):
-                            data_str = line[6:]
+                        # 兼容 `data:` 和 `data: ` 两种格式
+                        if line.startswith("data:"):
+                            data_str = line[5:].lstrip()
                             if data_str.strip() == "[DONE]":
                                 # 流结束，检查是否有工具调用需要处理
                                 if tool_calls_buffer:


### PR DESCRIPTION
## 问题描述 1：SSE 流式响应解析失败

某些 API 提供商（如 apis.iflow.cn）返回的 SSE 流式响应格式为 
data:{...}（无空格），而非 OpenAI 标准的 data: {...}（有空格）。

这导致流式响应解析失败，返回空内容，影响灵感模式等功能的正常使用。

### 修复内容

修改 backend/app/services/ai_clients/openai_client.py 中的流式响应解析逻辑，兼容两种 SSE 格式。

---

## 问题描述 2：Gemini 配置缺少 API 版本路径

.env.example 中 Gemini 的 BASE_URL 缺少必需的 /v1beta 路径。

### 修复内容

修正 backend/.env.example：
- GEMINI_BASE_URL: 添加 /v1beta
- 删除 Anthropic 配置（不需要支持）

---

## 问题描述 3：read_env_defaults() 不支持 Gemini

read_env_defaults() 函数只读取 OpenAI 的配置，当 DEFAULT_AI_PROVIDER=gemini 时，无法正确加载 Gemini 的 API Key 和 Base URL。

### 修复内容

修改 backend/app/api/settings.py：
- 根据 DEFAULT_AI_PROVIDER 返回对应的 API Key 和 Base URL
- 支持 openai、gemini 两种提供商（移除 anthropic 支持）

---

## 测试

- SSE 修复：已在 apis.iflow.cn 的 qwen3-max 模型上测试通过
- 配置修复：Gemini 路径现在与代码期望一致
- 默认配置修复：设置 DEFAULT_AI_PROVIDER=gemini 后，新用户首次使用能正确加载 Gemini 配置