### PR TITLE
fix: 修复 AI 项目生成流程重复触发的问题

### DIFF
--- a/frontend/src/components/AIProjectGenerator.tsx
+++ b/frontend/src/components/AIProjectGenerator.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Card, Button, Space, Typography, message, Progress, theme } from 'antd';
 import { CheckCircleOutlined, LoadingOutlined } from '@ant-design/icons';
@@ -77,6 +77,9 @@ export const AIProjectGenerator: React.FC<AIProjectGeneratorProps> = ({
   // 保存世界观生成结果，用于后续步骤
   const [worldBuildingResult, setWorldBuildingResult] = useState<WorldBuildingResult | null>(null);
 
+  // 防止重复触发的标志
+  const hasStartedRef = useRef(false);
+
   // LocalStorage 键名
   const storageKeys = {
     projectId: `${storagePrefix}_project_id`,
@@ -104,7 +107,8 @@ export const AIProjectGenerator: React.FC<AIProjectGeneratorProps> = ({
 
   // 开始自动化生成流程
   useEffect(() => {
-    if (config) {
+    if (config && !hasStartedRef.current) {
+      hasStartedRef.current = true;
       if (resumeProjectId) {
         // 恢复生成模式
         handleResumeGenerate(config, resumeProjectId);


### PR DESCRIPTION
### 问题描述
在 AIProjectGenerator 组件中，当父组件重新渲染时， useEffect 钩子会因为 config 对象引用的变化而重复执行，导致 generateWorldBuildingStream 被调用两次，造成不必要的 API 请求和资源浪费。

### 问题原因
- useEffect 依赖于 config 和 resumeProjectId
- 父组件重新渲染时会创建新的 config 对象（即使内容相同）
- 对象引用变化导致 useEffect 再次执行
- 生成流程被重复启动
### 解决方案
引入 useRef Hook 创建防重复触发标志，确保生成流程在组件生命周期内仅启动一次：

1. 引入 useRef Hook ：添加 hasStartedRef 作为防重复触发标志
2. 添加执行条件判断 ：在 useEffect 中检查 !hasStartedRef.current
3. 标记已启动 ：执行前将标志设为 true

### 测试
- [x] 创建新项目，验证生成流程只触发一次