### PR TITLE
feat(config): 添加时区配置和日志时间戳格式化功能

### DIFF
--- a/backend/app/logger.py
+++ b/backend/app/logger.py
@@ -44,9 +44,12 @@ class UvicornFormatter(logging.Formatter):
         request_id = getattr(record, 'request_id', None)
         request_id_str = f" [{request_id}]" if request_id else ""
         
-        # Uvicorn风格格式: INFO:     module_name - message [request_id]
+        # 格式化时间戳 (YYYY-MM-DD HH:MM:SS)
+        timestamp = self.formatTime(record, self.datefmt)
+        
+        # Uvicorn风格格式: INFO:     [2024-01-01 12:00:00] module_name - message [request_id]
         # 注意：INFO后面有5个空格，保持对齐
-        return f"{colored_level}:     {record.name}{request_id_str} - {record.getMessage()}"
+        return f"{colored_level}:     [{timestamp}] {record.name}{request_id_str} - {record.getMessage()}"
 
 
 # 全局标志，防止重复初始化

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,9 @@ services:
       - ./storage/generated_covers:/app/storage/generated_covers
       - ./.env:/app/.env:ro
     environment:
+      # 时区配置
+      - TZ=${TZ:-Asia/Shanghai}
+      
       # 应用配置
       - APP_NAME=${APP_NAME:-MuMuAINovel}
       - APP_VERSION=${APP_VERSION:-1.0.0}


### PR DESCRIPTION
- 在docker-compose.yml中添加TZ环境变量配置，默认设置为Asia/Shanghai
- 修改logger.py中的日志格式，添加时间戳显示功能
- 日志输出格式更新为[2024-01-01 12:00:00]格式的时间戳
- 保持与Uvicorn风格的日志格式兼容性

<img width="1558" height="766" alt="image" src="https://github.com/user-attachments/assets/8b45ebfb-72a5-4ddd-82be-dc1782526c59" />
