### PR TITLE
fix: 后台大纲续写添加缺失的组织校验调用

### DIFF
--- a/backend/app/api/outlines.py
+++ b/backend/app/api/outlines.py
@@ -2217,6 +2217,17 @@ async def _run_continue_outline_bg(
         except Exception:
             pass
 
+        # 组织校验
+        try:
+            await _check_and_create_missing_organizations_from_outlines(
+                outline_data=outline_data, project_id=project_id, db=db,
+                user_ai_service=user_ai_service, user_id=user_id,
+                enable_mcp=data.get("enable_mcp", True), tracker=tracker
+            )
+            await db.commit()
+        except Exception:
+            pass
+
     # 保存结果
     result_data = {
         "message": f"成功续写{len(all_new_outlines)}章大纲",


### PR DESCRIPTION
_run_continue_outline_bg 函数中只有角色校验，缺少组织校验。
与其他流程（全新生成、SSE续写）保持一致，添加 _check_and_create_missing_organizations_from_outlines 调用。