### PR TITLE
fix: 修复写作风格在章节生成时被重复注入的问题

### DIFF
--- a/backend/app/services/prompt_service.py
+++ b/backend/app/services/prompt_service.py
@@ -11,15 +11,18 @@ class WritingStyleManager:
         """
         将写作风格应用到基础提示词中
         
+        注意：写作风格已通过 system_prompt 注入（system_prompt_with_style），
+        此方法仅追加输出指令，不再重复注入 style_content，避免风格信息被注入两次。
+        
         Args:
             base_prompt: 基础提示词
-            style_content: 风格要求内容
+            style_content: 风格要求内容（已通过 system_prompt 注入，此处不使用）
             
         Returns:
-            组合后的提示词
+            追加输出指令后的提示词
         """
-        # 在基础提示词末尾添加风格要求
-        return f"{base_prompt}\n\n{style_content}\n\n请直接输出章节正文内容，不要包含章节标题和其他说明文字。"
+        # 写作风格已在 system_prompt 中注入，此处只追加输出格式指令
+        return f"{base_prompt}\n\n请直接输出章节正文内容，不要包含章节标题和其他说明文字。"
 
 
 class PromptService:


### PR DESCRIPTION
写作风格(style_content)同时被注入到 system_prompt 和 user prompt 中， 导致 AI 收到两份相同的风格指令。现在 apply_style_to_prompt() 仅追加
输出格式指令，风格注入统一由 system_prompt_with_style 负责。