### PR TITLE
Improve AI optimization workflows, chapter export, import parsing, and Gemini errors

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,6 +14,7 @@ build/
 
 # Node
 node_modules/
+**/node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ env/
 *~
 .DS_Store
 .kilocode/
+.playwright-cli/
 
 # Environment variables
 .env

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -53,6 +53,8 @@ CORS_ORIGINS=["http://localhost:8000","http://127.0.0.1:8000"]
 # HTTP_PROXY=http://your-proxy:port
 # HTTPS_PROXY=http://your-proxy:port
 # NO_PROXY=localhost,127.0.0.1
+# 仅本地 Clash fake-ip DNS 场景需要开启；生产环境建议保持 false
+ALLOW_DNS_PROXY_FAKE_IP=false
 
 # ==========================================
 # AI 服务配置（至少配置一个）

--- a/backend/app/api/careers.py
+++ b/backend/app/api/careers.py
@@ -26,6 +26,7 @@ from app.schemas.career import (
 )
 from app.services.ai_service import AIService
 from app.services.json_helper import loads_json
+from app.services.project_story_context import build_project_story_context
 from app.logger import get_logger
 from app.api.settings import get_user_ai_service
 from app.api.common import verify_project_access
@@ -214,6 +215,7 @@ async def generate_career_system(
             # 构建项目上下文
             yield await tracker.loading("分析项目世界观...", 0.6)
             
+            story_context = await build_project_story_context(db, project_id)
             project_context = f"""
 项目信息：
 - 书名：{project.title}
@@ -223,6 +225,8 @@ async def generate_career_system(
 - 地理位置：{project.world_location or '未设定'}
 - 氛围基调：{project.world_atmosphere or '未设定'}
 - 世界规则：{project.world_rules or '未设定'}
+
+{story_context}
 """
             
             sanitized_user_requirements = user_requirements.strip()
@@ -245,6 +249,8 @@ async def generate_career_system(
 - 本次新增主职业：{main_career_count}个
 - 本次新增副职业：{sub_career_count}个
 - ⚠️ 重要：请生成与已有职业**不重复**的新职业，形成互补体系
+- 必须结合已有大纲和章节中实际出现的时代、身份、阵营、技术/能力限制来设计职业
+- 优先补足已有剧情已经暗示但尚未入库的职业或能力路径
 - 新职业应填补已有职业体系的空缺，丰富职业多样性
 - 主职业必须严格符合世界观规则，体现核心能力体系
 - 副职业可以更加自由灵活，包含生产、辅助、特殊类型

--- a/backend/app/api/chapters.py
+++ b/backend/app/api/chapters.py
@@ -58,7 +58,13 @@ from app.services.foreshadow_service import foreshadow_service
 from app.services.chapter_regenerator import ChapterRegenerator
 from app.logger import get_logger
 from app.api.settings import get_user_ai_service, get_user_ai_service_from_db_by_usage
-from app.utils.sse_response import SSEResponse, create_sse_response
+from app.utils.sse_response import (
+    HEARTBEAT,
+    SSEResponse,
+    WizardProgressTracker,
+    create_sse_response,
+    wrap_stream_with_heartbeat,
+)
 
 router = APIRouter(prefix="/chapters", tags=["章节管理"])
 logger = get_logger(__name__)
@@ -73,6 +79,23 @@ async def get_db_write_lock(user_id: str) -> Lock:
         db_write_locks[user_id] = Lock()
         logger.debug(f"🔒 为用户 {user_id} 创建数据库写入锁")
     return db_write_locks[user_id]
+
+
+def _is_gemini_prompt_blocked_error(error: Optional[str]) -> bool:
+    if not error:
+        return False
+    markers = (
+        "promptFeedback.blockReason=PROHIBITED_CONTENT",
+        "Gemini 请求被拦截",
+    )
+    return any(marker in error for marker in markers)
+
+
+def _is_same_ai_service(left: AIService, right: AIService) -> bool:
+    return (
+        left.api_provider == right.api_provider
+        and left.default_model == right.default_model
+    )
 
 
 @router.post("", response_model=ChapterResponse, summary="创建章节")
@@ -969,11 +992,56 @@ async def analyze_chapter_background(
             on_retry=on_retry_callback,
             characters_info=characters_info
         )
+
+        analysis_error = getattr(analyzer, "last_error", None)
+
+        if not analysis_result and _is_gemini_prompt_blocked_error(analysis_error):
+            fallback_ai_service = await get_user_ai_service_from_db_by_usage(
+                user_id=user_id,
+                db=db_session,
+                usage="default"
+            )
+
+            if not _is_same_ai_service(ai_service, fallback_ai_service):
+                logger.warning(
+                    "⚠️ 章节分析专用 Gemini 模型被内容策略拦截，"
+                    f"改用默认模型兜底: {fallback_ai_service.api_provider}/{fallback_ai_service.default_model}"
+                )
+                async with write_lock:
+                    task.status = 'running'
+                    task.progress = max(task.progress or 0, 40)
+                    task.error_message = f"专用 Gemini 模型被拦截，正在使用默认模型兜底：{analysis_error[:150]}"
+                    await db_session.commit()
+
+                fallback_analyzer = PlotAnalyzer(fallback_ai_service)
+                analysis_result = await fallback_analyzer.analyze_chapter(
+                    chapter_number=chapter.chapter_number,
+                    title=chapter.title,
+                    content=chapter.content,
+                    word_count=chapter.word_count or len(chapter.content),
+                    user_id=user_id,
+                    db=db_session,
+                    max_retries=2,
+                    existing_foreshadows=existing_foreshadows,
+                    on_retry=on_retry_callback,
+                    characters_info=characters_info
+                )
+
+                if not analysis_result:
+                    fallback_error = getattr(fallback_analyzer, "last_error", None)
+                    analysis_error = (
+                        f"{analysis_error}；默认模型兜底失败: "
+                        f"{fallback_error or '未知错误'}"
+                    )
+                else:
+                    analysis_error = None
+            else:
+                logger.warning("⚠️ 默认模型与章节分析模型相同，跳过兜底重试")
         
         if not analysis_result:
             async with write_lock:
                 task.status = 'failed'
-                task.error_message = 'AI分析失败，请检查日志'
+                task.error_message = (analysis_error or 'AI分析失败，请检查日志')[:500]
                 task.completed_at = datetime.now()
                 await db_session.commit()
             logger.error(f"❌ AI分析失败: {chapter_id}")
@@ -1266,6 +1334,7 @@ async def analyze_chapter_background(
                 async with write_lock:
                     task.progress = 100
                     task.status = 'completed'
+                    task.error_message = None
                     task.completed_at = datetime.now()
                     await db_session.commit()
                     update_success = True
@@ -3281,9 +3350,14 @@ async def execute_batch_generation_in_order(
                                 
                                 # 直接根据返回值判断
                                 if not analysis_result:
-                                    last_analysis_error = "分析函数返回失败"
+                                    try:
+                                        await db_session.refresh(analysis_task)
+                                        last_analysis_error = analysis_task.error_message or "分析函数返回失败"
+                                    except Exception as refresh_error:
+                                        logger.warning(f"⚠️ 刷新分析任务错误信息失败: {refresh_error}")
+                                        last_analysis_error = "分析函数返回失败"
                                     logger.error(f"❌ 章节分析失败: 第{chapter.chapter_number}章")
-                                    raise Exception(f"章节分析失败")
+                                    raise Exception(last_analysis_error)
                                 
                                 # 分析成功
                                 analysis_success = True
@@ -4261,7 +4335,6 @@ async def partial_regenerate_stream(
     
     async def event_generator():
         """流式生成事件生成器"""
-        from app.utils.sse_response import WizardProgressTracker
         tracker = WizardProgressTracker("局部重写")
         
         try:
@@ -4326,7 +4399,36 @@ async def partial_regenerate_stream(
             )
             
             yield await tracker.preparing("开始生成...")
-            
+
+            def clean_rewrite_output(raw_text: str) -> str:
+                """Normalize model output without turning an empty response into success."""
+                cleaned = (raw_text or "").strip()
+                if cleaned.startswith("```"):
+                    lines = cleaned.splitlines()
+                    if lines and lines[0].strip().startswith("```"):
+                        lines = lines[1:]
+                    if lines and lines[-1].strip() == "```":
+                        lines = lines[:-1]
+                    cleaned = "\n".join(lines).strip()
+
+                prefixes_to_remove = [
+                    "重写后：", "重写后:", "改写后：", "改写后:",
+                    "以下是重写后的内容：", "以下是重写后的内容:",
+                    "重写内容：", "重写内容:"
+                ]
+                for prefix in prefixes_to_remove:
+                    if cleaned.startswith(prefix):
+                        cleaned = cleaned[len(prefix):].strip()
+                        break
+
+                if (cleaned.startswith('"') and cleaned.endswith('"')) or \
+                   (cleaned.startswith("'") and cleaned.endswith("'")):
+                    cleaned = cleaned[1:-1].strip()
+                if (cleaned.startswith('「') and cleaned.endswith('」')) or \
+                   (cleaned.startswith('『') and cleaned.endswith('』')):
+                    cleaned = cleaned[1:-1].strip()
+                return cleaned
+
             # 计算 max_tokens
             if partial_request.length_mode == "expand":
                 target_words = int(original_word_count * 2.0)
@@ -4334,60 +4436,92 @@ async def partial_regenerate_stream(
                 target_words = partial_request.target_word_count
             else:
                 target_words = int(original_word_count * 1.5)
-            
+
             calculated_max_tokens = max(500, min(int(target_words * 3), 8000))
-            
-            # 流式生成
+            max_attempts = 2
             full_content = ""
-            chunk_count = 0
-            
-            yield await tracker.generating(
-                current_chars=0,
-                estimated_total=target_words
-            )
-            
-            async for chunk in user_ai_service.generate_text_stream(
-                prompt=prompt,
-                max_tokens=calculated_max_tokens
-            ):
-                full_content += chunk
-                chunk_count += 1
-                
-                # 发送内容块
-                yield await tracker.generating_chunk(chunk)
-                
-                # 每5个chunk发送一次进度更新
-                if chunk_count % 5 == 0:
-                    yield await tracker.generating(
-                        current_chars=len(full_content),
-                        estimated_total=target_words,
-                        message=f'正在重写中... 已生成 {len(full_content)} 字'
+
+            for attempt in range(1, max_attempts + 1):
+                if await request.is_disconnected():
+                    logger.info("局部重写请求已由客户端断开")
+                    return
+
+                if attempt > 1:
+                    yield await tracker.retry(
+                        attempt - 1,
+                        max_attempts - 1,
+                        "AI返回空内容，正在重新生成"
                     )
-                
-                await asyncio.sleep(0)
-            
-            # 清理输出（移除可能的前后缀）
-            full_content = full_content.strip()
-            
-            # 移除常见的AI输出前缀
-            prefixes_to_remove = [
-                "重写后：", "重写后:", "改写后：", "改写后:",
-                "以下是重写后的内容：", "以下是重写后的内容:",
-                "重写内容：", "重写内容:"
-            ]
-            for prefix in prefixes_to_remove:
-                if full_content.startswith(prefix):
-                    full_content = full_content[len(prefix):].strip()
+
+                effective_prompt = prompt
+                if attempt > 1:
+                    effective_prompt = f"""{prompt}
+
+【重试修正】
+上一次模型没有返回可用正文。请务必直接输出可以替换原文的小说正文。
+禁止输出空白、解释、标题、Markdown、列表或任何前后缀。"""
+
+                raw_content = ""
+                chunk_count = 0
+
+                yield await tracker.generating(
+                    current_chars=0,
+                    estimated_total=target_words,
+                    retry_count=attempt - 1,
+                    max_retries=max_attempts - 1
+                )
+
+                async for chunk in wrap_stream_with_heartbeat(
+                    user_ai_service.generate_text_stream(
+                        prompt=effective_prompt,
+                        max_tokens=calculated_max_tokens
+                    ),
+                    heartbeat_interval=15.0
+                ):
+                    if chunk is HEARTBEAT:
+                        yield await tracker.heartbeat()
+                        continue
+
+                    if await request.is_disconnected():
+                        logger.info("局部重写请求已由客户端断开")
+                        return
+
+                    if not chunk:
+                        continue
+
+                    raw_content += chunk
+                    chunk_count += 1
+
+                    # 发送内容块
+                    yield await tracker.generating_chunk(chunk)
+
+                    # 每5个chunk发送一次进度更新
+                    if chunk_count % 5 == 0:
+                        yield await tracker.generating(
+                            current_chars=len(raw_content),
+                            estimated_total=target_words,
+                            message=f'正在重写中... 已生成 {len(raw_content)} 字',
+                            retry_count=attempt - 1,
+                            max_retries=max_attempts - 1
+                        )
+
+                    await asyncio.sleep(0)
+
+                full_content = clean_rewrite_output(raw_content)
+                if full_content:
                     break
-            
-            # 移除首尾可能的引号
-            if (full_content.startswith('"') and full_content.endswith('"')) or \
-               (full_content.startswith("'") and full_content.endswith("'")):
-                full_content = full_content[1:-1]
-            if (full_content.startswith('「') and full_content.endswith('」')) or \
-               (full_content.startswith('『') and full_content.endswith('』')):
-                full_content = full_content[1:-1]
-            
+
+                logger.warning(
+                    "局部重写返回空内容: chapter_id=%s attempt=%s raw_length=%s",
+                    chapter_id,
+                    attempt,
+                    len(raw_content or "")
+                )
+
+            if not full_content:
+                yield await tracker.error("AI未返回可用重写内容，请调整重写要求或更换模型后重试", 502)
+                return
+
             new_word_count = len(full_content)
             
             logger.info(f"✅ 局部重写完成: 原文{original_word_count}字 -> 新文{new_word_count}字")
@@ -4448,6 +4582,7 @@ async def apply_partial_regenerate(
     new_text = apply_request.get('new_text', '')
     start_position = apply_request.get('start_position', 0)
     end_position = apply_request.get('end_position', 0)
+    original_text = str(apply_request.get('original_text') or '')
     
     if not new_text:
         raise HTTPException(status_code=400, detail="新内容不能为空")
@@ -4456,6 +4591,38 @@ async def apply_partial_regenerate(
     content_length = len(chapter.content)
     if start_position < 0 or end_position > content_length or start_position >= end_position:
         raise HTTPException(status_code=400, detail="位置参数无效")
+
+    if original_text:
+        current_selected = chapter.content[start_position:end_position]
+        if current_selected != original_text:
+            search_start = max(0, start_position - 100)
+            search_end = min(content_length, end_position + 100)
+            search_area = chapter.content[search_start:search_end]
+            nearby_offset = search_area.find(original_text)
+
+            if nearby_offset >= 0:
+                start_position = search_start + nearby_offset
+                end_position = start_position + len(original_text)
+                logger.info(
+                    "局部重写应用位置校正: chapter_id=%s %s-%s",
+                    chapter_id,
+                    start_position,
+                    end_position
+                )
+            elif chapter.content.count(original_text) == 1:
+                start_position = chapter.content.find(original_text)
+                end_position = start_position + len(original_text)
+                logger.info(
+                    "局部重写应用位置全局校正: chapter_id=%s %s-%s",
+                    chapter_id,
+                    start_position,
+                    end_position
+                )
+            else:
+                raise HTTPException(
+                    status_code=409,
+                    detail="章节内容已变化，无法确认要替换的原文，请重新选择段落后再重写"
+                )
     
     # 构建新内容
     old_word_count = chapter.word_count or 0
@@ -4486,4 +4653,3 @@ async def apply_partial_regenerate(
         "old_word_count": old_word_count,
         "message": "局部重写已应用"
     }
-

--- a/backend/app/api/organizations.py
+++ b/backend/app/api/organizations.py
@@ -26,6 +26,7 @@ from app.schemas.character import CharacterResponse
 from app.services.ai_service import AIService
 from app.services.json_helper import loads_json
 from app.services.prompt_service import prompt_service, PromptService
+from app.services.project_story_context import build_project_story_context
 from app.logger import get_logger
 from app.api.settings import get_user_ai_service
 from app.api.common import verify_project_access
@@ -460,6 +461,7 @@ async def generate_organization_stream(
                     existing_info += "\n\n已有组织：\n" + "\n".join(organization_list)
             
             # 构建项目上下文
+            story_context = await build_project_story_context(db, gen_request.project_id)
             project_context = f"""
 项目信息：
 - 书名：{project.title}
@@ -470,6 +472,8 @@ async def generate_organization_stream(
 - 氛围基调：{project.world_atmosphere or '未设定'}
 - 世界规则：{project.world_rules or '未设定'}
 {existing_info}
+
+{story_context}
 """
             
             user_input = f"""

--- a/backend/app/api/polish.py
+++ b/backend/app/api/polish.py
@@ -1,17 +1,204 @@
 """AI去味API - 核心特色功能"""
-from fastapi import APIRouter, Depends, HTTPException, Request
-from sqlalchemy.ext.asyncio import AsyncSession
+import json
+from datetime import datetime
+from typing import Any, Dict, Optional
 
-from app.database import get_db
+from fastapi import APIRouter, Body, Depends, HTTPException, Request
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from app.api.common import verify_project_access
+from app.api.settings import get_user_ai_service, get_user_ai_service_from_db
+from app.database import get_db, get_engine
 from app.models.generation_history import GenerationHistory
-from app.schemas.polish import PolishRequest, PolishResponse
+from app.models.character import Character
+from app.models.outline import Outline
+from app.models.project import Project
+from app.models.relationship import Organization
+from app.schemas.polish import (
+    CharacterOptimizeTaskRequest,
+    OutlineOptimizeTaskRequest,
+    PolishRequest,
+    PolishResponse,
+)
 from app.services.ai_service import AIService
-from app.services.prompt_service import prompt_service, PromptService
+from app.services.background_task_service import background_task_service, TaskProgressTracker
+from app.services.prompt_service import PromptService
 from app.logger import get_logger
-from app.api.settings import get_user_ai_service
 
 router = APIRouter(prefix="/polish", tags=["AI去味"])
 logger = get_logger(__name__)
+
+POLISH_MAX_TOKENS_CEILING = 16000
+
+
+def _extract_generated_text(response) -> str:
+    """AIService returns a response dict; older callers expected a plain string."""
+    if isinstance(response, str):
+        return response
+    if isinstance(response, dict):
+        content = response.get("content", "")
+        return content if isinstance(content, str) else str(content or "")
+    return str(response or "")
+
+
+def _finish_reason(response) -> str:
+    if not isinstance(response, dict):
+        return ""
+    reason = response.get("finish_reason") or response.get("finishReason") or ""
+    return str(reason)
+
+
+def _polish_max_tokens(text: str, *, has_instruction: bool = False) -> int:
+    minimum = 4096 if has_instruction else 2048
+    requested = max(len(text or "") * 2, minimum)
+    return min(requested, POLISH_MAX_TOKENS_CEILING)
+
+
+def _ensure_non_empty_result(text: str, response, operation: str) -> str:
+    if text.strip():
+        return text
+    reason = _finish_reason(response)
+    if reason == "length":
+        raise HTTPException(status_code=502, detail=f"{operation}失败: AI输出被截断，请提高最大Tokens或换用更快模型")
+    raise HTTPException(status_code=502, detail=f"{operation}失败: AI返回空内容")
+
+
+def _strip_code_fence(text: str) -> str:
+    cleaned = (text or "").strip()
+    if cleaned.startswith("```"):
+        cleaned = cleaned.split("\n", 1)[1] if "\n" in cleaned else cleaned
+        if cleaned.endswith("```"):
+            cleaned = cleaned[:-3]
+    return cleaned.strip()
+
+
+def _parse_json_object(text: str) -> Optional[Dict[str, Any]]:
+    cleaned = _strip_code_fence(text)
+    try:
+        data = json.loads(cleaned)
+        return data if isinstance(data, dict) else None
+    except Exception:
+        start = cleaned.find("{")
+        end = cleaned.rfind("}")
+        if start == -1 or end == -1 or end <= start:
+            return None
+        try:
+            data = json.loads(cleaned[start:end + 1])
+            return data if isinstance(data, dict) else None
+        except Exception:
+            return None
+
+
+def _string_value(data: Optional[Dict[str, Any]], key: str) -> Optional[str]:
+    value = data.get(key) if data else None
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _string_list_value(data: Optional[Dict[str, Any]], key: str) -> Optional[list[str]]:
+    value = data.get(key) if data else None
+    if not isinstance(value, list):
+        return None
+    items = [item.strip() for item in value if isinstance(item, str) and item.strip()]
+    return items or None
+
+
+def _load_structure(structure: Optional[str]) -> Dict[str, Any]:
+    if not structure:
+        return {}
+    try:
+        data = json.loads(structure)
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _build_outline_optimize_source(outline: Outline, structure: Dict[str, Any], project: Project) -> str:
+    return json.dumps({
+        "project_title": project.title,
+        "order_index": outline.order_index,
+        "title": outline.title,
+        "content": outline.content or "",
+        "structure": structure,
+    }, ensure_ascii=False, indent=2)
+
+
+def _build_character_optimize_source(character: Character, organization: Optional[Organization]) -> str:
+    if character.is_organization:
+        return json.dumps({
+            "type": "organization",
+            "name": character.name,
+            "organization_type": character.organization_type or "",
+            "organization_purpose": character.organization_purpose or "",
+            "power_level": organization.power_level if organization else None,
+            "location": organization.location if organization else "",
+            "motto": organization.motto if organization else "",
+            "color": organization.color if organization else "",
+            "background": character.background or "",
+        }, ensure_ascii=False, indent=2)
+
+    return json.dumps({
+        "type": "character",
+        "name": character.name,
+        "role_type": character.role_type or "",
+        "age": character.age or "",
+        "gender": character.gender or "",
+        "personality": character.personality or "",
+        "appearance": character.appearance or "",
+        "background": character.background or "",
+    }, ensure_ascii=False, indent=2)
+
+
+OUTLINE_OPTIMIZE_INSTRUCTION = "\n".join([
+    "你是小说大纲编辑，请优化已有大纲。",
+    "只优化表达、层次、情节逻辑和可执行性，不要续写，不要新增章节，不改变章节编号、标题、核心事实、人物关系和世界观设定。",
+    "严格只输出 JSON，不要 Markdown，不要解释。",
+    "JSON 字段：content、key_points、key_events、emotion、goal。其中 content 必填，其他字段可按原设定优化后返回。",
+])
+
+
+CHARACTER_OPTIMIZE_INSTRUCTION = "\n".join([
+    "你是小说设定编辑，请优化角色设定。",
+    "只优化表达、层次和可读性，不改变既有事实、姓名、定位、年龄、性别、阵营、能力来源和时间线。",
+    "严格只输出 JSON，不要 Markdown，不要解释。",
+    "JSON 字段：personality、appearance、background。",
+])
+
+
+ORGANIZATION_OPTIMIZE_INSTRUCTION = "\n".join([
+    "你是小说设定编辑，请优化组织/势力设定。",
+    "只优化表达、层次和可读性，不改变既有事实、名称、阵营、世界观和时间线。",
+    "严格只输出 JSON，不要 Markdown，不要解释。",
+    "JSON 字段：organization_purpose、motto、background。",
+])
+
+
+async def _generate_optimized_text(
+    ai_service: AIService,
+    source: str,
+    instruction: str,
+    provider: Optional[str] = None,
+    model: Optional[str] = None,
+    temperature: Optional[float] = 0.6,
+) -> str:
+    response = await ai_service.generate_text(
+        prompt=f"{instruction}\n\n请处理以下内容：\n{source}",
+        provider=provider,
+        model=model,
+        temperature=temperature,
+        max_tokens=_polish_max_tokens(source, has_instruction=True),
+    )
+    return _ensure_non_empty_result(_extract_generated_text(response), response, "AI优化")
+
+
+async def _build_denoising_prompt(original_text: str, user_id: Optional[str], db: AsyncSession) -> str:
+    template = await PromptService.get_template_with_fallback("AI_DENOISING", user_id, db)
+    if not template:
+        template = PromptService.AI_DENOISING
+    return PromptService.format_prompt(template, original_text=original_text)
 
 
 @router.post("", response_model=PolishResponse, summary="AI去味")
@@ -35,25 +222,33 @@ async def polish_text(
     try:
         # 获取用户ID
         user_id = getattr(http_request.state, 'user_id', None)
+
+        if request.project_id:
+            await verify_project_access(request.project_id, user_id, db)
         
-        # 获取自定义提示词模板
-        template = await PromptService.get_template("AI_DENOISING", user_id, db)
-        # 格式化提示词
-        prompt = PromptService.format_prompt(
-            template,
-            original_text=request.original_text
-        )
+        if request.instruction:
+            prompt = (
+                f"{request.instruction.strip()}\n\n"
+                "请处理以下内容：\n"
+                f"{request.original_text}"
+            )
+        else:
+            prompt = await _build_denoising_prompt(request.original_text, user_id, db)
         
         logger.info(f"开始AI去味处理，原文长度: {len(request.original_text)}")
         
         # 调用AI进行去味处理
-        polished_text = await user_ai_service.generate_text(
+        ai_response = await user_ai_service.generate_text(
             prompt=prompt,
             provider=request.provider,
             model=request.model,
             temperature=request.temperature,
-            max_tokens=len(request.original_text) * 2  # 预留足够token
+            max_tokens=_polish_max_tokens(
+                request.original_text,
+                has_instruction=bool(request.instruction)
+            )
         )
+        polished_text = _ensure_non_empty_result(_extract_generated_text(ai_response), ai_response, "AI去味")
         
         # 计算字数
         word_count_before = len(request.original_text)
@@ -65,10 +260,8 @@ async def polish_text(
         if request.project_id:
             history = GenerationHistory(
                 project_id=request.project_id,
-                generation_type="polish",
                 prompt=f"原文: {request.original_text[:100]}...",
-                result=polished_text,
-                provider=request.provider or "default",
+                generated_content=polished_text,
                 model=request.model or "default"
             )
             db.add(history)
@@ -81,17 +274,333 @@ async def polish_text(
             word_count_after=word_count_after
         )
         
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"AI去味失败: {str(e)}")
         raise HTTPException(status_code=500, detail=f"AI去味失败: {str(e)}")
 
 
+@router.post("/outlines/background", summary="后台优化已有大纲")
+async def optimize_outlines_background(
+    data: OutlineOptimizeTaskRequest,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+):
+    """创建后台任务优化已有大纲，进度和取消走统一后台任务面板。"""
+    user_id = getattr(request.state, "user_id", None)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="未登录")
+
+    await verify_project_access(data.project_id, user_id, db)
+
+    if data.outline_ids:
+        result = await db.execute(
+            select(Outline.id).where(
+                Outline.project_id == data.project_id,
+                Outline.id.in_(data.outline_ids)
+            )
+        )
+        found_ids = {row[0] for row in result.all()}
+        missing_count = len(set(data.outline_ids) - found_ids)
+        if missing_count:
+            raise HTTPException(status_code=400, detail=f"有 {missing_count} 条大纲不存在或不属于当前项目")
+
+    task = await background_task_service.create_task(
+        user_id=user_id,
+        project_id=data.project_id,
+        task_type="outline_optimize",
+        task_input=data.model_dump(),
+        db=db,
+    )
+    await background_task_service.spawn_background_task(
+        task.id,
+        user_id,
+        _run_outline_optimize_background,
+        data.model_dump(),
+    )
+
+    return {
+        "task_id": task.id,
+        "task_type": "outline_optimize",
+        "status": "pending",
+        "message": "大纲优化任务已创建，请通过后台任务面板查看进度"
+    }
+
+
+@router.post("/characters/background", summary="后台优化角色/组织设定")
+async def optimize_characters_background(
+    data: CharacterOptimizeTaskRequest,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+):
+    """创建后台任务优化角色/组织设定，进度和取消走统一后台任务面板。"""
+    user_id = getattr(request.state, "user_id", None)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="未登录")
+
+    await verify_project_access(data.project_id, user_id, db)
+
+    if not data.character_ids:
+        raise HTTPException(status_code=400, detail="请选择要优化的角色或组织")
+
+    result = await db.execute(
+        select(Character.id).where(
+            Character.project_id == data.project_id,
+            Character.id.in_(data.character_ids)
+        )
+    )
+    found_ids = {row[0] for row in result.all()}
+    missing_count = len(set(data.character_ids) - found_ids)
+    if missing_count:
+        raise HTTPException(status_code=400, detail=f"有 {missing_count} 个角色/组织不存在或不属于当前项目")
+
+    task = await background_task_service.create_task(
+        user_id=user_id,
+        project_id=data.project_id,
+        task_type="character_optimize",
+        task_input=data.model_dump(),
+        db=db,
+    )
+    await background_task_service.spawn_background_task(
+        task.id,
+        user_id,
+        _run_character_optimize_background,
+        data.model_dump(),
+    )
+
+    return {
+        "task_id": task.id,
+        "task_type": "character_optimize",
+        "status": "pending",
+        "message": "角色设定优化任务已创建，请通过后台任务面板查看进度"
+    }
+
+
+async def _run_outline_optimize_background(task_id: str, user_id: str, data: Dict[str, Any]):
+    engine = await get_engine(user_id)
+    AsyncSessionLocal = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with AsyncSessionLocal() as bg_db:
+        tracker = TaskProgressTracker(task_id, user_id, "大纲优化")
+        try:
+            if await tracker.check_cancelled():
+                return
+            await tracker.start("开始优化已有大纲...")
+
+            project_id = data["project_id"]
+            outline_ids = data.get("outline_ids")
+
+            await tracker.loading("加载项目信息...", 0.4)
+            project_result = await bg_db.execute(select(Project).where(Project.id == project_id))
+            project = project_result.scalar_one_or_none()
+            if not project:
+                raise ValueError("项目不存在")
+
+            await tracker.loading("加载大纲列表...", 0.8)
+            query = select(Outline).where(Outline.project_id == project_id)
+            if outline_ids:
+                query = query.where(Outline.id.in_(outline_ids))
+            query = query.order_by(Outline.order_index)
+            outlines_result = await bg_db.execute(query)
+            outlines = outlines_result.scalars().all()
+            if not outlines:
+                raise ValueError("没有可优化的大纲")
+
+            ai_service = await get_user_ai_service_from_db(user_id, bg_db)
+            total = len(outlines)
+            succeeded = 0
+            failed: list[Dict[str, str]] = []
+
+            await tracker.preparing(f"共 {total} 条大纲，准备逐条优化...")
+            for idx, outline in enumerate(outlines):
+                if await tracker.check_cancelled():
+                    return
+
+                await tracker.generating(
+                    current_chars=idx,
+                    estimated_total=total,
+                    message=f"正在优化 {idx + 1}/{total}：{outline.title}"
+                )
+
+                try:
+                    structure = _load_structure(outline.structure)
+                    source = _build_outline_optimize_source(outline, structure, project)
+                    optimized_text = await _generate_optimized_text(
+                        ai_service=ai_service,
+                        source=source,
+                        instruction=OUTLINE_OPTIMIZE_INSTRUCTION,
+                        provider=data.get("provider"),
+                        model=data.get("model"),
+                        temperature=data.get("temperature") or 0.6,
+                    )
+                    parsed = _parse_json_object(optimized_text)
+                    content = (
+                        _string_value(parsed, "content")
+                        or _string_value(parsed, "summary")
+                        or _strip_code_fence(optimized_text)
+                    )
+                    if not content:
+                        raise ValueError("AI优化结果为空")
+
+                    next_structure = {
+                        **structure,
+                        "summary": content,
+                        "content": content,
+                    }
+                    key_points = _string_list_value(parsed, "key_points")
+                    key_events = _string_list_value(parsed, "key_events")
+                    emotion = _string_value(parsed, "emotion")
+                    goal = _string_value(parsed, "goal")
+
+                    if key_points:
+                        next_structure["key_points"] = key_points
+                    if key_events:
+                        next_structure["key_events"] = key_events
+                    if emotion:
+                        next_structure["emotion"] = emotion
+                    if goal:
+                        next_structure["goal"] = goal
+
+                    outline.content = content
+                    outline.structure = json.dumps(next_structure, ensure_ascii=False, indent=2)
+                    outline.updated_at = datetime.now()
+                    await bg_db.commit()
+                    succeeded += 1
+                except Exception as item_error:
+                    await bg_db.rollback()
+                    failed.append({"id": outline.id, "title": outline.title, "error": str(item_error)})
+                    logger.error(f"优化大纲失败: {outline.title} - {item_error}", exc_info=True)
+
+            result = {"total": total, "succeeded": succeeded, "failed": failed}
+            await tracker.saving("保存优化结果...", 1)
+            await tracker._update_task(task_result=result)
+            if failed:
+                await tracker.complete(f"大纲优化完成：成功 {succeeded} 条，失败 {len(failed)} 条")
+            else:
+                await tracker.complete(f"大纲优化完成，共 {succeeded} 条")
+        except Exception as e:
+            logger.error(f"后台大纲优化失败: {e}", exc_info=True)
+            await tracker.error(str(e))
+
+
+async def _run_character_optimize_background(task_id: str, user_id: str, data: Dict[str, Any]):
+    engine = await get_engine(user_id)
+    AsyncSessionLocal = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with AsyncSessionLocal() as bg_db:
+        tracker = TaskProgressTracker(task_id, user_id, "角色设定优化")
+        try:
+            if await tracker.check_cancelled():
+                return
+            await tracker.start("开始优化角色/组织设定...")
+
+            project_id = data["project_id"]
+            character_ids = data["character_ids"]
+
+            await tracker.loading("加载角色列表...", 0.6)
+            characters_result = await bg_db.execute(
+                select(Character)
+                .where(Character.project_id == project_id, Character.id.in_(character_ids))
+                .order_by(Character.created_at)
+            )
+            characters = characters_result.scalars().all()
+            if not characters:
+                raise ValueError("没有可优化的角色或组织")
+
+            ai_service = await get_user_ai_service_from_db(user_id, bg_db)
+            total = len(characters)
+            succeeded = 0
+            failed: list[Dict[str, str]] = []
+
+            await tracker.preparing(f"共 {total} 个角色/组织，准备逐个优化...")
+            for idx, character in enumerate(characters):
+                if await tracker.check_cancelled():
+                    return
+
+                await tracker.generating(
+                    current_chars=idx,
+                    estimated_total=total,
+                    message=f"正在优化 {idx + 1}/{total}：{character.name}"
+                )
+
+                try:
+                    organization = None
+                    if character.is_organization:
+                        org_result = await bg_db.execute(
+                            select(Organization).where(Organization.character_id == character.id)
+                        )
+                        organization = org_result.scalar_one_or_none()
+
+                    source = _build_character_optimize_source(character, organization)
+                    optimized_text = await _generate_optimized_text(
+                        ai_service=ai_service,
+                        source=source,
+                        instruction=ORGANIZATION_OPTIMIZE_INSTRUCTION if character.is_organization else CHARACTER_OPTIMIZE_INSTRUCTION,
+                        provider=data.get("provider"),
+                        model=data.get("model"),
+                        temperature=data.get("temperature") or 0.6,
+                    )
+                    parsed = _parse_json_object(optimized_text)
+                    if not parsed:
+                        raise ValueError("AI返回格式无法识别")
+
+                    if character.is_organization:
+                        purpose = _string_value(parsed, "organization_purpose")
+                        motto = _string_value(parsed, "motto")
+                        background = _string_value(parsed, "background")
+                        if purpose:
+                            character.organization_purpose = purpose
+                        if background:
+                            character.background = background
+                        if motto:
+                            if organization:
+                                organization.motto = motto
+                            else:
+                                organization = Organization(
+                                    character_id=character.id,
+                                    project_id=character.project_id,
+                                    member_count=0,
+                                    motto=motto,
+                                )
+                                bg_db.add(organization)
+                    else:
+                        personality = _string_value(parsed, "personality")
+                        appearance = _string_value(parsed, "appearance")
+                        background = _string_value(parsed, "background")
+                        if personality:
+                            character.personality = personality
+                        if appearance:
+                            character.appearance = appearance
+                        if background:
+                            character.background = background
+
+                    character.updated_at = datetime.now()
+                    await bg_db.commit()
+                    succeeded += 1
+                except Exception as item_error:
+                    await bg_db.rollback()
+                    failed.append({"id": character.id, "name": character.name, "error": str(item_error)})
+                    logger.error(f"优化角色设定失败: {character.name} - {item_error}", exc_info=True)
+
+            result = {"total": total, "succeeded": succeeded, "failed": failed}
+            await tracker.saving("保存优化结果...", 1)
+            await tracker._update_task(task_result=result)
+            if failed:
+                await tracker.complete(f"角色设定优化完成：成功 {succeeded} 个，失败 {len(failed)} 个")
+            else:
+                await tracker.complete(f"角色设定优化完成，共 {succeeded} 个")
+        except Exception as e:
+            logger.error(f"后台角色设定优化失败: {e}", exc_info=True)
+            await tracker.error(str(e))
+
+
 @router.post("/batch", summary="批量AI去味")
 async def polish_batch(
-    texts: list[str],
-    project_id: int = None,
-    provider: str = None,
-    model: str = None,
+    payload: Any = Body(...),
+    project_id: Optional[str] = None,
+    provider: Optional[str] = None,
+    model: Optional[str] = None,
     http_request: Request = None,
     db: AsyncSession = Depends(get_db),
     user_ai_service: AIService = Depends(get_user_ai_service)
@@ -104,22 +613,36 @@ async def polish_batch(
     try:
         # 获取用户ID
         user_id = getattr(http_request.state, 'user_id', None) if http_request else None
+
+        if isinstance(payload, dict):
+            texts = payload.get("texts") or []
+            project_id = payload.get("project_id") or project_id
+            provider = payload.get("provider") or provider
+            model = payload.get("model") or model
+        else:
+            texts = payload
+
+        if project_id:
+            await verify_project_access(project_id, user_id, db)
+
+        if not isinstance(texts, list) or not all(isinstance(text, str) for text in texts):
+            raise HTTPException(status_code=400, detail="texts 必须是字符串数组")
         
         results = []
         
         for idx, text in enumerate(texts):
             logger.info(f"处理第 {idx+1}/{len(texts)} 个文本")
             
-            # 获取自定义提示词模板
-            template = await PromptService.get_template("AI_DENOISING", user_id, db)
-            # 格式化提示词
-            prompt = PromptService.format_prompt(template, original_text=text)
+            prompt = await _build_denoising_prompt(text, user_id, db)
             
-            polished_text = await user_ai_service.generate_text(
+            ai_response = await user_ai_service.generate_text(
                 prompt=prompt,
                 provider=provider,
-                model=model
+                model=model,
+                temperature=0.8,
+                max_tokens=_polish_max_tokens(text)
             )
+            polished_text = _ensure_non_empty_result(_extract_generated_text(ai_response), ai_response, "批量AI去味")
             
             results.append({
                 "index": idx,
@@ -133,9 +656,12 @@ async def polish_batch(
         
         return {
             "total": len(results),
+            "polished_texts": [item["polished"] for item in results],
             "results": results
         }
         
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"批量AI去味失败: {str(e)}")
         raise HTTPException(status_code=500, detail=f"批量AI去味失败: {str(e)}")

--- a/backend/app/api/projects.py
+++ b/backend/app/api/projects.py
@@ -1,10 +1,12 @@
 """项目管理API"""
-from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Request
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Request, Query
 from fastapi.responses import Response
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func, delete
-from typing import List
+from typing import List, Optional
 import json
+import io
+import zipfile
 from urllib.parse import quote
 from app.database import get_db
 from app.models.project import Project
@@ -346,11 +348,14 @@ async def delete_project(
 @router.get("/{project_id}/export", summary="导出项目章节为TXT")
 async def export_project_chapters(
     project_id: str,
+    start_chapter: Optional[int] = Query(None, ge=1, description="起始章节号"),
+    end_chapter: Optional[int] = Query(None, ge=1, description="结束章节号"),
+    split: bool = Query(False, description="是否按章节拆分为ZIP"),
     db: AsyncSession = Depends(get_db),
     request: Request = None
 ):
     """
-    导出项目的所有章节内容为TXT文本文件
+    导出项目章节内容为TXT文本文件
     按章节顺序组织，使用便于再次拆书导入的纯章节格式
     """
     try:
@@ -360,7 +365,14 @@ async def export_project_chapters(
             logger.warning("未登录用户尝试导出项目")
             raise HTTPException(status_code=401, detail="未登录")
         
-        logger.info(f"开始导出项目: project_id={project_id}, user_id={user_id}")
+        if start_chapter is not None and end_chapter is not None and start_chapter > end_chapter:
+            raise HTTPException(status_code=400, detail="起始章节不能大于结束章节")
+
+        logger.info(
+            "开始导出项目: "
+            f"project_id={project_id}, user_id={user_id}, "
+            f"start={start_chapter}, end={end_chapter}, split={split}"
+        )
         
         # 只查询当前用户的项目
         result = await db.execute(
@@ -375,48 +387,86 @@ async def export_project_chapters(
             logger.warning(f"项目不存在或无权访问: project_id={project_id}, user_id={user_id}")
             raise HTTPException(status_code=404, detail="项目不存在")
         
-        chapters_result = await db.execute(
-            select(Chapter)
-            .where(Chapter.project_id == project_id)
-            .order_by(Chapter.chapter_number)
-        )
+        chapters_query = select(Chapter).where(Chapter.project_id == project_id)
+        if start_chapter is not None:
+            chapters_query = chapters_query.where(Chapter.chapter_number >= start_chapter)
+        if end_chapter is not None:
+            chapters_query = chapters_query.where(Chapter.chapter_number <= end_chapter)
+
+        chapters_result = await db.execute(chapters_query.order_by(Chapter.chapter_number))
         chapters = chapters_result.scalars().all()
         
         if not chapters:
             logger.warning(f"项目没有章节: {project_id}")
-            raise HTTPException(status_code=404, detail="项目没有任何章节")
+            raise HTTPException(status_code=404, detail="指定范围内没有任何章节")
         
-        txt_content = []
-        
-        for idx, chapter in enumerate(chapters):
+        def format_chapter_text(chapter: Chapter) -> str:
             chapter_title = (chapter.title or "").strip() or f"未命名章节{chapter.chapter_number}"
             raw_content = (chapter.content or "").strip()
+            formatted_lines = []
             if raw_content:
-                formatted_lines = []
                 for line in raw_content.splitlines():
                     stripped_line = line.strip()
                     if stripped_line:
                         formatted_lines.append(f"　　{stripped_line}")
                     else:
                         formatted_lines.append("")
-                chapter_content = "\n".join(formatted_lines)
             else:
-                chapter_content = "　　（本章暂无内容）"
-            
-            # 使用拆书强匹配可稳定识别的章节标题格式：第X章 标题
-            txt_content.append(f"第{chapter.chapter_number}章 {chapter_title}")
-            txt_content.append(chapter_content)
-            
+                formatted_lines.append("　　（本章暂无内容）")
+
+            return "\n".join([
+                f"第{chapter.chapter_number}章 {chapter_title}",
+                "\n".join(formatted_lines)
+            ])
+
+        def safe_filename_part(value: str) -> str:
+            cleaned = "".join(c for c in value if c.isalnum() or c in (' ', '-', '_', '，', '。', '、'))
+            return cleaned.strip() or "未命名项目"
+
+        safe_title = safe_filename_part(project.title or "未命名项目")
+        if start_chapter is not None or end_chapter is not None:
+            actual_start = chapters[0].chapter_number
+            actual_end = chapters[-1].chapter_number
+            range_suffix = f"_第{actual_start}-{actual_end}章"
+        else:
+            range_suffix = ""
+
+        if split:
+            zip_buffer = io.BytesIO()
+            with zipfile.ZipFile(zip_buffer, mode="w", compression=zipfile.ZIP_DEFLATED) as zip_file:
+                for chapter in chapters:
+                    chapter_title = safe_filename_part(chapter.title or f"未命名章节{chapter.chapter_number}")
+                    chapter_filename = f"第{chapter.chapter_number:03d}章_{chapter_title}.txt"
+                    zip_file.writestr(chapter_filename, format_chapter_text(chapter).encode('utf-8'))
+
+            zip_buffer.seek(0)
+            filename = f"{safe_title}{range_suffix}_分章.zip"
+            encoded_filename = quote(filename)
+
+            logger.info(f"分章导出成功: {filename}, 共{len(chapters)}章")
+
+            return Response(
+                content=zip_buffer.getvalue(),
+                media_type="application/zip",
+                headers={
+                    "Content-Disposition": f"attachment; filename*=UTF-8''{encoded_filename}",
+                    "Content-Type": "application/zip"
+                }
+            )
+
+        txt_content = []
+
+        for idx, chapter in enumerate(chapters):
+            txt_content.append(format_chapter_text(chapter))
+
             # 章节之间只保留一个空行，避免装饰性分割线干扰拆书识别
             if idx < len(chapters) - 1:
                 txt_content.append("")
         
         final_content = "\n".join(txt_content)
         
-        safe_title = "".join(c for c in (project.title or "未命名项目") if c.isalnum() or c in (' ', '-', '_', '，', '。', '、'))
-        filename = f"{safe_title}.txt"
+        filename = f"{safe_title}{range_suffix}.txt"
         
-        from urllib.parse import quote
         encoded_filename = quote(filename)
         
         logger.info(f"导出成功: {filename}, 共{len(chapters)}章, {len(final_content)}字符")

--- a/backend/app/api/relationships.py
+++ b/backend/app/api/relationships.py
@@ -1,10 +1,13 @@
 """关系管理API"""
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, or_, and_
-from typing import List, Optional
+from sqlalchemy import select, or_
+from typing import List, Optional, AsyncGenerator
+from pydantic import BaseModel, Field
+import json
 
 from app.database import get_db
+from app.utils.sse_response import SSEResponse, create_sse_response, WizardProgressTracker, wrap_stream_with_heartbeat, HEARTBEAT
 from app.models.relationship import (
     RelationshipType,
     CharacterRelationship,
@@ -12,7 +15,7 @@ from app.models.relationship import (
     OrganizationMember
 )
 from app.models.character import Character
-from app.models.project import Project
+from app.models.generation_history import GenerationHistory
 from app.schemas.relationship import (
     RelationshipTypeResponse,
     CharacterRelationshipCreate,
@@ -24,9 +27,20 @@ from app.schemas.relationship import (
 )
 from app.logger import get_logger
 from app.api.common import verify_project_access
+from app.api.settings import get_user_ai_service
+from app.services.ai_service import AIService
+from app.services.json_helper import loads_json
+from app.services.project_story_context import build_project_story_context
 
 router = APIRouter(prefix="/relationships", tags=["关系管理"])
 logger = get_logger(__name__)
+
+
+class RelationshipGenerateRequest(BaseModel):
+    """AI生成角色关系的请求模型"""
+    project_id: str = Field(..., description="项目ID")
+    relationship_count: int = Field(8, ge=1, le=50, description="生成关系数量")
+    requirements: Optional[str] = Field(None, description="额外要求")
 
 
 @router.get("/types", response_model=List[RelationshipTypeResponse], summary="获取关系类型列表")
@@ -155,6 +169,240 @@ async def get_relationship_graph(
         f"{len(relationships)} 条角色关系，{len(member_links)} 条组织成员关系"
     )
     return RelationshipGraphData(nodes=nodes, links=links)
+
+
+@router.post("/generate-stream", summary="AI分析大纲/章节生成角色关系（流式）")
+async def generate_relationships_stream(
+    gen_request: RelationshipGenerateRequest,
+    http_request: Request,
+    db: AsyncSession = Depends(get_db),
+    user_ai_service: AIService = Depends(get_user_ai_service)
+):
+    """使用已有角色、大纲和章节分析生成角色关系，返回SSE进度。"""
+    async def generate() -> AsyncGenerator[str, None]:
+        tracker = WizardProgressTracker("角色关系")
+        try:
+            user_id = getattr(http_request.state, 'user_id', None)
+            project = await verify_project_access(gen_request.project_id, user_id, db)
+
+            yield await tracker.start()
+            yield await tracker.loading("加载角色和已有关系...", 0.25)
+
+            characters_result = await db.execute(
+                select(Character)
+                .where(
+                    Character.project_id == gen_request.project_id,
+                    Character.is_organization == False
+                )
+                .order_by(Character.created_at.asc())
+            )
+            characters = characters_result.scalars().all()
+            if len(characters) < 2:
+                yield await tracker.error("至少需要两个角色才能分析生成关系")
+                return
+
+            relationships_result = await db.execute(
+                select(CharacterRelationship)
+                .where(CharacterRelationship.project_id == gen_request.project_id)
+            )
+            existing_relationships = relationships_result.scalars().all()
+
+            character_by_id = {character.id: character for character in characters}
+            character_name_counts: dict[str, int] = {}
+            for character in characters:
+                character_name_counts[character.name] = character_name_counts.get(character.name, 0) + 1
+            unique_character_by_name = {
+                character.name: character
+                for character in characters
+                if character_name_counts.get(character.name, 0) == 1
+            }
+            existing_pairs = {
+                frozenset((relationship.character_from_id, relationship.character_to_id))
+                for relationship in existing_relationships
+            }
+
+            character_context = "\n".join(
+                f"- ID:{character.id}｜{character.name}（{character.role_type or '角色'}）"
+                f"：{(character.background or character.personality or '暂无设定')[:180]}"
+                for character in characters[:80]
+            )
+            existing_context = "\n".join(
+                f"- {character_by_id.get(relationship.character_from_id).name if character_by_id.get(relationship.character_from_id) else '未知'}"
+                f" -> {character_by_id.get(relationship.character_to_id).name if character_by_id.get(relationship.character_to_id) else '未知'}"
+                f"：{relationship.relationship_name or '关系'}，亲密度{relationship.intimacy_level}"
+                for relationship in existing_relationships[:80]
+            ) or "暂无已入库关系"
+
+            yield await tracker.loading("分析已有大纲和章节...", 0.55)
+            story_context = await build_project_story_context(db, gen_request.project_id)
+
+            requirements = (gen_request.requirements or "").strip() or "无"
+            prompt = f"""
+你是小说人物关系分析师。请基于项目已有角色、大纲和章节，补充生成尚未入库的角色关系。
+
+项目信息：
+- 书名：{project.title}
+- 类型：{project.genre or '未设定'}
+- 主题：{project.theme or '未设定'}
+- 世界规则：{project.world_rules or '未设定'}
+
+【已有角色】
+{character_context}
+
+【已入库关系】
+{existing_context}
+
+{story_context}
+
+用户要求：
+{requirements}
+
+生成要求：
+- 本次最多生成 {gen_request.relationship_count} 条关系
+- 只能使用【已有角色】中的角色 ID，ID 必须完全匹配
+- 优先从已有大纲和章节中的同伴、敌对、上下级、旧识、亲属、师承、合作、利用等关系中提取
+- 不要重复已入库关系，不要生成没有文本依据的臆测关系
+- intimacy_level 使用 -100 到 100，敌对为负，疏离/复杂接近0，亲近为正
+- status 只能为 active、broken、past、complicated
+- 只输出 JSON，不要 Markdown，不要解释
+
+返回格式：
+{{
+  "relationships": [
+    {{
+      "character_from_id": "角色A的ID",
+      "character_to_id": "角色B的ID",
+      "character_from_name": "角色A名称",
+      "character_to_name": "角色B名称",
+      "relationship_name": "关系名称",
+      "intimacy_level": 50,
+      "status": "active",
+      "description": "关系依据和简述",
+      "started_at": "关系开始时间或章节，可选"
+    }}
+  ]
+}}
+"""
+
+            yield await tracker.generating(0, max(3000, len(prompt) * 8), "调用AI分析生成关系...")
+            ai_content = ""
+            chunk_count = 0
+            estimated_total = max(3000, len(prompt) * 8)
+            async for chunk in wrap_stream_with_heartbeat(
+                user_ai_service.generate_text_stream(prompt=prompt),
+                heartbeat_interval=15.0
+            ):
+                if chunk is HEARTBEAT:
+                    yield await tracker.heartbeat()
+                    continue
+
+                chunk_count += 1
+                ai_content += chunk
+                yield await SSEResponse.send_chunk(chunk)
+                if chunk_count % 8 == 0:
+                    yield await tracker.generating(len(ai_content), estimated_total)
+
+            if not ai_content.strip():
+                yield await tracker.error("AI服务返回空响应")
+                return
+
+            yield await tracker.parsing("解析AI返回的关系数据...", 0.65)
+            try:
+                cleaned_response = user_ai_service._clean_json_response(ai_content)
+                relationship_data = loads_json(cleaned_response)
+            except json.JSONDecodeError as e:
+                logger.error(f"关系JSON解析失败: {e}")
+                yield await tracker.error(f"AI返回的内容无法解析为JSON：{str(e)}")
+                return
+            if not isinstance(relationship_data, dict):
+                yield await tracker.error("AI返回格式不正确：应为JSON对象")
+                return
+
+            created_relationships: list[str] = []
+            skipped_count = 0
+            allowed_statuses = {"active", "broken", "past", "complicated"}
+            relationship_items = relationship_data.get("relationships") or []
+            if not isinstance(relationship_items, list):
+                yield await tracker.error("AI返回格式不正确：relationships 应为数组")
+                return
+
+            def resolve_character(item: dict, id_key: str, name_key: str) -> Optional[Character]:
+                character_id = str(item.get(id_key) or "").strip()
+                if character_id:
+                    return character_by_id.get(character_id)
+                character_name = str(item.get(name_key) or "").strip()
+                if character_name:
+                    return unique_character_by_name.get(character_name)
+                return None
+
+            yield await tracker.saving("保存关系到数据库...", 0.8)
+            for item in relationship_items[:gen_request.relationship_count]:
+                if not isinstance(item, dict):
+                    skipped_count += 1
+                    continue
+                from_character = resolve_character(item, "character_from_id", "character_from_name")
+                to_character = resolve_character(item, "character_to_id", "character_to_name")
+                if not from_character or not to_character or from_character.id == to_character.id:
+                    skipped_count += 1
+                    continue
+
+                pair_key = frozenset((from_character.id, to_character.id))
+                if pair_key in existing_pairs:
+                    skipped_count += 1
+                    continue
+
+                try:
+                    intimacy_level = int(item.get("intimacy_level", 50))
+                except (TypeError, ValueError):
+                    intimacy_level = 50
+                intimacy_level = max(-100, min(100, intimacy_level))
+
+                status = str(item.get("status") or "active").strip()
+                if status not in allowed_statuses:
+                    status = "active"
+
+                relationship = CharacterRelationship(
+                    project_id=gen_request.project_id,
+                    character_from_id=from_character.id,
+                    character_to_id=to_character.id,
+                    relationship_name=str(item.get("relationship_name") or "关联").strip()[:100],
+                    intimacy_level=intimacy_level,
+                    status=status,
+                    description=str(item.get("description") or "").strip() or None,
+                    started_at=str(item.get("started_at") or "").strip() or None,
+                    source="ai"
+                )
+                db.add(relationship)
+                existing_pairs.add(pair_key)
+                created_relationships.append(
+                    f"{from_character.name} - {to_character.name}: {relationship.relationship_name}"
+                )
+
+            history = GenerationHistory(
+                project_id=gen_request.project_id,
+                prompt=prompt,
+                generated_content=ai_content,
+                model=user_ai_service.default_model
+            )
+            db.add(history)
+            await db.commit()
+
+            yield await tracker.complete(f"关系生成完成，新增 {len(created_relationships)} 条")
+            yield await tracker.result({
+                "created_count": len(created_relationships),
+                "skipped_count": skipped_count,
+                "relationships": created_relationships
+            })
+            yield await tracker.done()
+
+        except HTTPException as he:
+            logger.error(f"HTTP异常: {he.detail}")
+            yield await tracker.error(he.detail, he.status_code)
+        except Exception as e:
+            logger.error(f"生成关系失败: {str(e)}", exc_info=True)
+            yield await tracker.error(f"生成关系失败: {str(e)}")
+
+    return create_sse_response(generate())
 
 
 @router.post("/", response_model=CharacterRelationshipResponse, summary="创建角色关系")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -80,6 +80,9 @@ class Settings(BaseSettings):
     
     # MCP配置
     mcp_max_rounds: int = 3  # MCP工具调用最大轮数（全局统一控制）
+
+    # 出站 URL 安全配置
+    allow_dns_proxy_fake_ip: bool = False  # 仅本地代理 fake-ip DNS 场景需要开启，生产环境建议保持关闭
     
     # LinuxDO OAuth2 配置
     LINUXDO_CLIENT_ID: Optional[str] = None

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -147,7 +147,7 @@ from app.api import (
     auth, users, settings, writing_styles, memories,
     mcp_plugins, admin, inspiration, prompt_templates,
     changelog, careers, foreshadows, prompt_workshop, book_import,
-    project_covers, tasks
+    project_covers, tasks, polish
 )
 
 app.include_router(auth.router, prefix="/api")
@@ -159,6 +159,7 @@ app.include_router(projects.router, prefix="/api")
 app.include_router(project_covers.router, prefix="/api")
 app.include_router(wizard_stream.router, prefix="/api")
 app.include_router(inspiration.router, prefix="/api")
+app.include_router(polish.router, prefix="/api")
 app.include_router(outlines.router, prefix="/api")
 app.include_router(characters.router, prefix="/api")
 app.include_router(careers.router, prefix="/api")  # 职业管理API

--- a/backend/app/schemas/polish.py
+++ b/backend/app/schemas/polish.py
@@ -1,15 +1,16 @@
 """AI去味相关的Pydantic模型"""
 from pydantic import BaseModel, Field
-from typing import Optional
+from typing import List, Optional
 
 
 class PolishRequest(BaseModel):
     """AI去味请求模型"""
     original_text: str = Field(..., description="原始文本（AI生成的文本）")
-    project_id: Optional[int] = Field(None, description="项目ID（可选，用于记录历史）")
+    project_id: Optional[str] = Field(None, description="项目ID（可选，用于记录历史）")
     provider: Optional[str] = Field(None, description="AI提供商")
     model: Optional[str] = Field(None, description="AI模型")
     temperature: Optional[float] = Field(0.8, description="温度参数，建议0.7-0.9")
+    instruction: Optional[str] = Field(None, description="本次润色/优化的附加指令")
 
 
 class PolishResponse(BaseModel):
@@ -18,3 +19,21 @@ class PolishResponse(BaseModel):
     polished_text: str = Field(..., description="去味后的文本")
     word_count_before: int = Field(..., description="处理前字数")
     word_count_after: int = Field(..., description="处理后字数")
+
+
+class OutlineOptimizeTaskRequest(BaseModel):
+    """后台优化大纲请求"""
+    project_id: str = Field(..., description="项目ID")
+    outline_ids: Optional[List[str]] = Field(None, description="要优化的大纲ID列表；为空则优化项目全部大纲")
+    provider: Optional[str] = Field(None, description="AI提供商")
+    model: Optional[str] = Field(None, description="AI模型")
+    temperature: Optional[float] = Field(0.6, description="温度参数")
+
+
+class CharacterOptimizeTaskRequest(BaseModel):
+    """后台优化角色/组织请求"""
+    project_id: str = Field(..., description="项目ID")
+    character_ids: List[str] = Field(..., description="要优化的角色/组织ID列表")
+    provider: Optional[str] = Field(None, description="AI提供商")
+    model: Optional[str] = Field(None, description="AI模型")
+    temperature: Optional[float] = Field(0.6, description="温度参数")

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -15,6 +15,11 @@ from fastapi import HTTPException
 from app.config import settings
 
 
+DNS_PROXY_FAKE_IP_NETWORKS = (
+    ipaddress.ip_network("198.18.0.0/15"),
+)
+
+
 def _session_secret() -> bytes:
     secret = (
         getattr(settings, "SESSION_SECRET_KEY", None)
@@ -74,6 +79,11 @@ def _is_forbidden_ip(ip: ipaddress._BaseAddress) -> bool:
     ])
 
 
+def _is_dns_proxy_fake_ip(ip: ipaddress._BaseAddress) -> bool:
+    """Recognize Clash-style fake-ip DNS answers."""
+    return any(ip in network for network in DNS_PROXY_FAKE_IP_NETWORKS)
+
+
 def validate_public_http_url(raw_url: str, *, allowed_schemes: Iterable[str] = ("https", "http")) -> str:
     """Validate an outbound URL to reduce SSRF risk."""
     if not raw_url or not isinstance(raw_url, str):
@@ -103,6 +113,12 @@ def validate_public_http_url(raw_url: str, *, allowed_schemes: Iterable[str] = (
         for info in infos:
             resolved_ip = ipaddress.ip_address(info[4][0])
             if _is_forbidden_ip(resolved_ip):
+                allow_fake_ip = (
+                    settings.allow_dns_proxy_fake_ip
+                    and _is_dns_proxy_fake_ip(resolved_ip)
+                )
+                if allow_fake_ip:
+                    continue
                 raise HTTPException(status_code=400, detail="URL解析到内网或保留地址")
 
     return raw_url.strip().rstrip("/")

--- a/backend/app/services/ai_clients/gemini_client.py
+++ b/backend/app/services/ai_clients/gemini_client.py
@@ -1,10 +1,19 @@
 """Gemini 客户端"""
 from typing import Any, AsyncGenerator, Dict, List, Optional
+import json
 import httpx
 from app.services.ai_config import AIClientConfig, default_config
 from app.logger import get_logger
 
 logger = get_logger(__name__)
+
+
+class GeminiResponseError(ValueError):
+    """Gemini 返回了非 HTTP 错误，但没有可用正文。"""
+
+
+class GeminiPromptBlockedError(GeminiResponseError):
+    """Gemini 在 promptFeedback 层拦截了请求。"""
 
 
 class GeminiClient:
@@ -44,6 +53,64 @@ class GeminiClient:
                 gemini_tools.append(decl)
         return [{"functionDeclarations": gemini_tools}] if gemini_tools else []
 
+    def _normalize_finish_reason(self, finish_reason: Optional[str]) -> str:
+        mapping = {
+            "STOP": "stop",
+            "MAX_TOKENS": "length",
+            "SAFETY": "safety",
+            "RECITATION": "recitation",
+            "OTHER": "other",
+            "BLOCKLIST": "blocklist",
+            "PROHIBITED_CONTENT": "prohibited_content",
+            "SPII": "spii",
+            "MALFORMED_FUNCTION_CALL": "malformed_function_call",
+        }
+        if not finish_reason:
+            return "stop"
+        return mapping.get(finish_reason, finish_reason.lower())
+
+    def _compact_safety_ratings(self, ratings: Optional[list]) -> str:
+        if not ratings:
+            return ""
+        compact = []
+        for rating in ratings[:6]:
+            category = rating.get("category")
+            probability = rating.get("probability")
+            blocked = rating.get("blocked")
+            parts = [str(x) for x in (category, probability) if x]
+            if blocked is True:
+                parts.append("blocked=True")
+            if parts:
+                compact.append("/".join(parts))
+        return "; ".join(compact)
+
+    def _usage_from_metadata(self, usage: Dict[str, Any]) -> Dict[str, Optional[int]]:
+        return {
+            "prompt_tokens": usage.get("promptTokenCount"),
+            "completion_tokens": usage.get("candidatesTokenCount"),
+            "total_tokens": usage.get("totalTokenCount"),
+        }
+
+    def _raise_for_prompt_block(self, data: Dict[str, Any]) -> None:
+        prompt_feedback = data.get("promptFeedback") or {}
+        block_reason = prompt_feedback.get("blockReason")
+        if not block_reason:
+            return
+
+        ratings = self._compact_safety_ratings(prompt_feedback.get("safetyRatings"))
+        message = f"Gemini 请求被拦截: promptFeedback.blockReason={block_reason}"
+        if ratings:
+            message += f", safetyRatings={ratings}"
+        raise GeminiPromptBlockedError(message)
+
+    def _raise_for_empty_candidate(self, candidate: Dict[str, Any]) -> None:
+        finish_reason = candidate.get("finishReason")
+        ratings = self._compact_safety_ratings(candidate.get("safetyRatings"))
+        message = f"Gemini 返回空候选: finishReason={finish_reason or 'UNKNOWN'}"
+        if ratings:
+            message += f", safetyRatings={ratings}"
+        raise GeminiResponseError(message)
+
     async def chat_completion(
         self,
         messages: list,
@@ -73,17 +140,14 @@ class GeminiClient:
         response = await self.client.post(url, json=payload)
         response.raise_for_status()
         data = response.json()
+        self._raise_for_prompt_block(data)
         
         candidates = data.get("candidates", [])
         if not candidates or len(candidates) == 0:
-            # 返回空内容而不是报错，保持流程继续
-            return {
-                "content": "",
-                "tool_calls": None,
-                "finish_reason": "stop"
-            }
+            raise GeminiResponseError("Gemini 返回空 candidates")
         
-        parts = candidates[0].get("content", {}).get("parts", [])
+        candidate = candidates[0]
+        parts = candidate.get("content", {}).get("parts", [])
         text = ""
         tool_calls = []
         
@@ -97,20 +161,16 @@ class GeminiClient:
                     "type": "function",
                     "function": {"name": fc["name"], "arguments": fc.get("args", {})}
                 })
+
+        if not text and not tool_calls:
+            self._raise_for_empty_candidate(candidate)
         
         usage = data.get("usageMetadata") or {}
-        prompt_tokens = usage.get("promptTokenCount")
-        completion_tokens = usage.get("candidatesTokenCount")
-        total_tokens = usage.get("totalTokenCount")
         return {
             "content": text,
             "tool_calls": tool_calls if tool_calls else None,
-            "finish_reason": "tool_calls" if tool_calls else "stop",
-            "usage": {
-                "prompt_tokens": prompt_tokens,
-                "completion_tokens": completion_tokens,
-                "total_tokens": total_tokens,
-            }
+            "finish_reason": "tool_calls" if tool_calls else self._normalize_finish_reason(candidate.get("finishReason")),
+            "usage": self._usage_from_metadata(usage)
         }
 
     async def chat_completion_stream(
@@ -152,23 +212,25 @@ class GeminiClient:
             async with self.client.stream("POST", url, json=payload) as response:
                 response.raise_for_status()
                 try:
+                    saw_content = False
+                    saw_tool_calls = False
+                    saw_finish_reason = False
+
                     async for line in response.aiter_lines():
                         if line.startswith("data: "):
-                            import json
                             try:
                                 data = json.loads(line[6:])
                                 usage = data.get("usageMetadata") or {}
                                 if usage:
-                                    yield {
-                                        "usage": {
-                                            "prompt_tokens": usage.get("promptTokenCount"),
-                                            "completion_tokens": usage.get("candidatesTokenCount"),
-                                            "total_tokens": usage.get("totalTokenCount"),
-                                        }
-                                    }
+                                    yield {"usage": self._usage_from_metadata(usage)}
+
+                                self._raise_for_prompt_block(data)
+
                                 candidates = data.get("candidates", [])
                                 if candidates and len(candidates) > 0:
-                                    parts = candidates[0].get("content", {}).get("parts", [])
+                                    candidate = candidates[0]
+                                    parts = candidate.get("content", {}).get("parts", [])
+                                    finish_reason = candidate.get("finishReason")
                                     if parts and len(parts) > 0:
                                         text = ""
                                         function_calls = []
@@ -187,11 +249,25 @@ class GeminiClient:
                                                 })
                                         
                                         if text:
+                                            saw_content = True
                                             yield {"content": text}
                                         if function_calls:
+                                            saw_tool_calls = True
                                             yield {"tool_calls": function_calls}
+
+                                    if finish_reason:
+                                        saw_finish_reason = True
+                                        if not parts and (finish_reason != "STOP" or (not saw_content and not saw_tool_calls)):
+                                            self._raise_for_empty_candidate(candidate)
+                                        yield {
+                                            "finish_reason": self._normalize_finish_reason(finish_reason),
+                                            "done": True
+                                        }
                             except json.JSONDecodeError:
                                 continue
+
+                    if not saw_content and not saw_tool_calls and not saw_finish_reason:
+                        raise GeminiResponseError("Gemini 流式响应没有返回正文或结束原因")
                 except GeneratorExit:
                     # 生成器被关闭，这是正常的清理过程
                     logger.debug("Gemini 流式响应生成器被关闭(GeneratorExit)")

--- a/backend/app/services/background_task_service.py
+++ b/backend/app/services/background_task_service.py
@@ -188,6 +188,9 @@ class BackgroundTaskService:
                     logger.info(f"🔄 [用户{user_id[:8]}] 队列开始执行任务: {task_id[:8]} (队列剩余: {queue.qsize()})")
 
                     try:
+                        if await self._is_task_cancelled_before_start(task_id, user_id):
+                            logger.info(f"🚫 [用户{user_id[:8]}] 任务已在排队时取消，跳过执行: {task_id[:8]}")
+                            continue
                         await task_func(task_id, args["user_id"], *args["extra_args"], **kwargs)
                     except Exception as e:
                         logger.error(f"❌ 后台任务 {task_id[:8]} 异常: {e}", exc_info=True)
@@ -381,6 +384,28 @@ class BackgroundTaskService:
         return {
             uid: q.qsize() for uid, q in self._user_queues.items() if q.qsize() > 0
         }
+
+    @staticmethod
+    async def _is_task_cancelled_before_start(task_id: str, user_id: str) -> bool:
+        """避免排队中已取消的任务被 worker 重新拉起。"""
+        try:
+            engine = await get_engine(user_id)
+            AsyncSessionLocal = async_sessionmaker(
+                engine, class_=AsyncSession, expire_on_commit=False
+            )
+            async with AsyncSessionLocal() as session:
+                result = await session.execute(
+                    select(BackgroundTask.status, BackgroundTask.cancel_requested)
+                    .where(BackgroundTask.id == task_id)
+                )
+                row = result.one_or_none()
+                if not row:
+                    return True
+                status, cancel_requested = row
+                return status == "cancelled" or bool(cancel_requested)
+        except Exception as e:
+            logger.error(f"检查任务取消状态失败: {e}")
+            return False
 
 
 # 全局单例

--- a/backend/app/services/book_import_service.py
+++ b/backend/app/services/book_import_service.py
@@ -216,7 +216,8 @@ class BookImportService:
                 db=db,
                 user_id=user_id,
                 project=project,
-                character_count=max(project.character_count or 0, 8),
+                character_count=max(project.character_count or 0, 5),
+                chapters=chapters_to_import,
             )
             statistics["generated_world_building"] = generated_world
             statistics["generated_careers"] = generated_careers
@@ -380,6 +381,7 @@ class BookImportService:
                     count=character_count_target,
                     progress_callback=progress_callback,
                     progress_range=(67, 92),
+                    source_chapters=chapters_to_import,
                 )
                 statistics["generated_entities"] = generated_entities
                 await _notify(f"👥 角色/组织生成完成（{generated_entities}个）", 92)
@@ -542,6 +544,7 @@ class BookImportService:
                             count=character_count_target,
                             progress_callback=progress_callback,
                             progress_range=(step_start_pct, step_end_pct),
+                            source_chapters=task.preview.chapters if task.preview else None,
                         )
                         retry_results["generated_entities"] = result
                         await _notify(f"✅ 角色/组织重试成功（{result}个）", step_end_pct)
@@ -1262,7 +1265,7 @@ class BookImportService:
         fallback_outlines = [
             BookImportOutline(
                 title=chapter.title,
-                content=(chapter.summary or self._build_summary(chapter.content or "")),
+                content=self._build_fallback_outline_summary(chapter),
                 order_index=chapter.chapter_number,
                 structure=self._build_fallback_outline_structure(chapter),
             )
@@ -1435,9 +1438,7 @@ class BookImportService:
         }
 
     def _build_fallback_outline_structure(self, chapter: BookImportChapter) -> dict[str, Any]:
-        summary = (chapter.summary or self._build_summary(chapter.content or "")).strip()
-        if not summary:
-            summary = "本章围绕主要人物与核心冲突推进剧情。"
+        summary = self._build_fallback_outline_summary(chapter)
 
         return {
             "chapter_number": chapter.chapter_number,
@@ -1455,6 +1456,11 @@ class BookImportService:
             "emotion": "紧张递进",
             "goal": "承接前章并推动后续剧情发展",
         }
+
+    def _build_fallback_outline_summary(self, chapter: BookImportChapter) -> str:
+        summary = chapter.summary or self._build_summary(chapter.content or "")
+        normalized = str(summary or "").strip()
+        return normalized or "本章围绕主要人物与核心冲突推进剧情。"
 
     def _build_fallback_project_suggestion(
         self,
@@ -1634,6 +1640,7 @@ class BookImportService:
         user_id: str,
         project: Project,
         character_count: int,
+        chapters: Optional[list[BookImportChapter]] = None,
     ) -> tuple[int, int, int]:
         """
         走“向导前3步”的核心链路：
@@ -1659,6 +1666,7 @@ class BookImportService:
             user_id=user_id,
             project=project,
             count=character_count,
+            source_chapters=chapters,
         )
 
         # 拆书导入场景不需要继续到大纲，直接标记流程完成，避免项目列表再次跳向导生成大纲
@@ -1834,6 +1842,253 @@ class BookImportService:
         await db.flush()
         return created
 
+    def _build_import_source_text(
+        self,
+        chapters: Optional[list[BookImportChapter]],
+        *,
+        max_chars: int = 80000,
+    ) -> str:
+        if not chapters:
+            return ""
+
+        parts: list[str] = []
+        remaining = max_chars
+        for chapter in chapters:
+            if remaining <= 0:
+                break
+
+            title = str(chapter.title or "").strip()
+            content = str(chapter.content or "").strip()
+            if title:
+                title_part = title[:remaining]
+                parts.append(title_part)
+                remaining -= len(title_part)
+            if content:
+                if remaining <= 0:
+                    break
+                content_part = content[:remaining]
+                parts.append(content_part)
+                remaining -= len(content_part)
+        return "\n".join(parts)
+
+    def _build_import_source_prompt_context(
+        self,
+        chapters: Optional[list[BookImportChapter]],
+        *,
+        max_chars: int = 10000,
+    ) -> str:
+        if not chapters:
+            return ""
+
+        parts: list[str] = []
+        for chapter in chapters[:30]:
+            title = str(chapter.title or "").strip() or f"第{chapter.chapter_number}章"
+            content = str(chapter.content or "").strip()
+            excerpt = content[:500]
+            parts.append(f"第{chapter.chapter_number}章《{title}》\n{excerpt}")
+
+        context = "\n\n".join(parts).strip()
+        return context[:max_chars]
+
+    def _extract_import_source_name_candidates(
+        self,
+        *,
+        source_text: str,
+        title: str,
+        limit: int = 30,
+    ) -> list[str]:
+        if not source_text:
+            return []
+
+        stopwords = {
+            "放学", "教室", "数学", "老师", "粉笔", "黑板", "学校", "今天", "时候", "朋友",
+            "什么", "身体", "眼睛", "世界", "魔物", "情绪", "心灵", "魔法", "少女", "不是",
+            "这个", "那个", "一下", "一声", "一个", "一只", "一层", "一步", "一点", "一样",
+            "里面", "第一", "第二", "第三", "第四", "第五", "体育", "男生", "女生", "同学",
+            "书包", "课桌", "手机", "图书", "图书馆", "舞台", "后台", "体育馆", "城市", "空气",
+            "然后", "只是", "他们", "可以", "低头", "右手", "自己", "声音", "看了", "她能",
+            "事情", "对方", "以后", "原本", "现在", "这里", "那里", "心里", "手里", "身边",
+        }
+        counter: Counter[str] = Counter()
+
+        title_candidate = re.sub(
+            r"(魔法|少女|少年|传说|传|录|记|篇|小说|测试文|\s+)",
+            "",
+            title or "",
+        )
+        if 2 <= len(title_candidate) <= 4 and title_candidate in source_text:
+            counter[title_candidate] += source_text.count(title_candidate) + 1000
+
+        verbs = (
+            "说|问|喊|叫|笑|看|站|走|跑|盯|抬|低|拿|想|听|点|摇|伸|皱|咬|推|坐|转|愣|"
+            "开口|回答|眨|叹|冲|抓|握|扶|闭|睁|发现|感觉|知道|觉得|意识|沉默"
+        )
+        patterns = [
+            rf"([\u4e00-\u9fff]{{2,4}})(?=(?:{verbs}))",
+            rf"(?:叫|喊|问|对|看向|拉住|推了推)([\u4e00-\u9fff]{{2,4}})",
+        ]
+
+        match_counter: Counter[str] = Counter()
+        for pattern in patterns:
+            for match in re.finditer(pattern, source_text):
+                name = self._normalize_import_source_name_candidate(match.group(1))
+                if not name or name in stopwords:
+                    continue
+                match_counter[name] += 1
+
+        for name, occurrences in match_counter.items():
+            if occurrences >= 3:
+                counter[name] += occurrences
+
+        return [name for name, _ in counter.most_common(limit)]
+
+    def _normalize_import_source_name_candidate(self, value: Any) -> str:
+        name = str(value or "").strip()
+        name = re.sub(r"^(但|而|可|又|便|于是|然后|如果|因为|只是|只有|那个|这个|她|他|它|你|我)+", "", name)
+        name = re.sub(r"(轻声|猛地|慢慢|突然|尖|下|没|不|能|想|在)$", "", name)
+        if not re.fullmatch(r"[\u4e00-\u9fff]{2,4}", name):
+            return ""
+        return name
+
+    def _resolve_import_source_entity_name(
+        self,
+        name: Any,
+        *,
+        source_text: str,
+        source_names: list[str],
+    ) -> Optional[str]:
+        raw_name = str(name or "").strip()
+        if not raw_name:
+            return None
+        if raw_name in source_text:
+            return raw_name
+
+        for candidate in source_names:
+            if raw_name.endswith(candidate) or candidate.endswith(raw_name):
+                return candidate
+
+        for size in range(min(4, len(raw_name) - 1), 1, -1):
+            suffix = raw_name[-size:]
+            if suffix in source_text and source_text.count(suffix) >= 3:
+                return suffix
+
+        return None
+
+    def _build_import_fallback_entity(self, name: str, index: int) -> dict[str, Any]:
+        return {
+            "name": name,
+            "age": None,
+            "gender": "未知",
+            "is_organization": False,
+            "role_type": "protagonist" if index == 0 else "supporting",
+            "personality": "由拆书导入根据原文出现频率自动建立，具体性格可在角色卡中继续补充。",
+            "background": "该角色明确出现在导入原文中，系统未额外补写原文之外的人物经历。",
+            "appearance": "原文未在当前抽取阶段形成稳定外貌描述，可后续手动完善。",
+            "traits": [],
+            "relationships_array": [],
+            "organization_memberships": [],
+        }
+
+    def _ground_generated_entities_to_source(
+        self,
+        generated_entities: list[Any],
+        *,
+        source_text: str,
+        source_names: list[str],
+        target_count: int,
+    ) -> list[dict[str, Any]]:
+        normalized_items: list[dict[str, Any]] = []
+        seen_names: set[str] = set()
+        dropped_names: list[str] = []
+
+        for item in generated_entities:
+            if not isinstance(item, dict):
+                continue
+
+            raw_name = str(item.get("name") or "").strip()
+            if not raw_name:
+                continue
+
+            is_organization = bool(item.get("is_organization", False))
+            if is_organization:
+                normalized_name = raw_name if raw_name in source_text else None
+            else:
+                normalized_name = self._resolve_import_source_entity_name(
+                    raw_name,
+                    source_text=source_text,
+                    source_names=source_names,
+                )
+
+            if not normalized_name:
+                dropped_names.append(raw_name)
+                continue
+            if normalized_name in seen_names:
+                continue
+
+            normalized = dict(item)
+            normalized["name"] = normalized_name
+            normalized_items.append(normalized)
+            seen_names.add(normalized_name)
+
+        fallback_limit = min(target_count, 5)
+        for name in source_names:
+            if len(normalized_items) >= fallback_limit:
+                break
+            if name in seen_names:
+                continue
+            normalized_items.append(self._build_import_fallback_entity(name, len(normalized_items)))
+            seen_names.add(name)
+
+        kept_names = {str(item.get("name") or "") for item in normalized_items}
+        organization_names = {
+            str(item.get("name") or "")
+            for item in normalized_items
+            if bool(item.get("is_organization", False))
+        }
+
+        for item in normalized_items:
+            relationships = item.get("relationships_array")
+            if isinstance(relationships, list):
+                filtered_relationships: list[dict[str, Any]] = []
+                for rel in relationships:
+                    if not isinstance(rel, dict):
+                        continue
+                    target_name = self._resolve_import_source_entity_name(
+                        rel.get("target_character_name"),
+                        source_text=source_text,
+                        source_names=source_names,
+                    )
+                    if not target_name or target_name not in kept_names or target_name == item.get("name"):
+                        continue
+                    normalized_rel = dict(rel)
+                    normalized_rel["target_character_name"] = target_name
+                    filtered_relationships.append(normalized_rel)
+                item["relationships_array"] = filtered_relationships
+
+            memberships = item.get("organization_memberships")
+            if isinstance(memberships, list):
+                item["organization_memberships"] = [
+                    membership
+                    for membership in memberships
+                    if isinstance(membership, dict)
+                    and str(membership.get("organization_name") or "").strip() in organization_names
+                ]
+
+            org_members = item.get("organization_members")
+            if isinstance(org_members, list):
+                item["organization_members"] = [
+                    name for name in org_members
+                    if str(name or "").strip() in kept_names
+                ]
+
+        if dropped_names:
+            logger.info(
+                "拆书导入过滤原文未出现的角色/组织: %s",
+                "、".join(dropped_names[:20]),
+            )
+
+        return normalized_items[:target_count]
+
     async def _generate_characters_and_organizations_from_project(
         self,
         *,
@@ -1843,6 +2098,7 @@ class BookImportService:
         count: int,
         progress_callback: Any = None,
         progress_range: tuple[int, int] = (0, 100),
+        source_chapters: Optional[list[BookImportChapter]] = None,
     ) -> int:
         """根据世界观+职业体系生成角色/组织，并补全职业和组织成员关系。"""
 
@@ -1873,12 +2129,28 @@ class BookImportService:
 
         await _notify("👥 正在准备角色生成提示词...", 0.15)
         template = await PromptService.get_template("CHARACTERS_BATCH_GENERATION", user_id, db)
+        source_text = self._build_import_source_text(source_chapters)
+        source_names = self._extract_import_source_name_candidates(
+            source_text=source_text,
+            title=project.title or "",
+        )
         requirements = (
             "请生成能够支撑前期剧情推进的关键角色与组织，"
             "角色和组织都要与世界观、职业体系一致。"
             "如果包含组织，数量不超过2个。"
             "请尽量为非组织角色补充 organization_memberships。"
         )
+        if source_text:
+            source_context = self._build_import_source_prompt_context(source_chapters)
+            requirements = (
+                "这是拆书导入项目，角色卡必须从原文抽取，不是重新创作。"
+                "只能使用原文中明确出现的角色名或组织名，禁止推断姓氏、禁止补充原文不存在的新角色。"
+                "主角姓名必须与原文保持一致；如果原文只写“晓卡”，就必须输出“晓卡”，不能改成“苏晓卡”等全名。"
+                "原文未出现的组织不要生成；如果组织名不明确，可以只生成角色。"
+                f"原文高频候选名：{'、'.join(source_names[:5]) or '未识别'}。\n"
+                f"【原文节选】\n{source_context}\n\n"
+                + requirements
+            )
 
         if main_careers or sub_careers:
             careers_context = "\n\n【职业分配要求】\n"
@@ -1916,6 +2188,13 @@ class BookImportService:
             generated_entities = generated_data
         else:
             generated_entities = []
+        if source_text:
+            generated_entities = self._ground_generated_entities_to_source(
+                generated_entities,
+                source_text=source_text,
+                source_names=source_names,
+                target_count=target_count,
+            )
 
         # 预加载角色/组织，便于去重和兼容 append 场景的名称引用
         existing_chars_result = await db.execute(select(Character).where(Character.project_id == project.id))

--- a/backend/app/services/plot_analyzer.py
+++ b/backend/app/services/plot_analyzer.py
@@ -27,7 +27,18 @@ class PlotAnalyzer:
             ai_service: AI服务实例
         """
         self.ai_service = ai_service
+        self.last_error: Optional[str] = None
         logger.info("✅ PlotAnalyzer初始化成功")
+
+    @staticmethod
+    def _is_non_retryable_ai_error(error: Optional[str]) -> bool:
+        if not error:
+            return False
+        non_retryable_markers = (
+            "promptFeedback.blockReason=PROHIBITED_CONTENT",
+            "Gemini 请求被拦截",
+        )
+        return any(marker in error for marker in non_retryable_markers)
     
     async def analyze_chapter(
         self,
@@ -61,6 +72,7 @@ class PlotAnalyzer:
             分析结果字典,失败返回None
         """
         logger.info(f"🔍 开始分析第{chapter_number}章: {title}")
+        self.last_error = None
         
         # 如果内容过长,截取前8000字(避免超token)
         analysis_content = content[:8000] if len(content) > 8000 else content
@@ -89,6 +101,14 @@ class PlotAnalyzer:
             existing_foreshadows=foreshadows_text,
             characters_info=characters_info if characters_info else "（暂无角色信息）"
         )
+
+        if self.ai_service.api_provider == "gemini":
+            prompt = (
+                "以下任务是虚构中文网络小说的文学结构分析。"
+                "请只分析剧情、角色状态、伏笔和叙事结构；"
+                "不要扩展、模仿或生成现实伤害内容。\n\n"
+                f"{prompt}"
+            )
         
         last_error = None
         logger.debug(f"章节分析提示词{prompt}")
@@ -118,6 +138,7 @@ class PlotAnalyzer:
                 if not accumulated_text or len(accumulated_text.strip()) < 10:
                     logger.warning(f"⚠️ AI响应为空或过短(长度: {len(accumulated_text)}), 尝试 {attempt}/{max_retries}")
                     last_error = "AI响应为空或过短"
+                    self.last_error = last_error
                     if attempt < max_retries:
                         wait_time = min(2 ** attempt, 10)
                         logger.info(f"  ⏳ 等待 {wait_time} 秒后重试...")
@@ -151,6 +172,7 @@ class PlotAnalyzer:
                     # JSON解析失败，重试
                     logger.warning(f"⚠️ JSON解析失败, 尝试 {attempt}/{max_retries}")
                     last_error = "JSON解析失败"
+                    self.last_error = last_error
                     if attempt < max_retries:
                         wait_time = min(2 ** attempt, 10)
                         logger.info(f"  ⏳ 等待 {wait_time} 秒后重试...")
@@ -168,7 +190,12 @@ class PlotAnalyzer:
                     
             except Exception as e:
                 last_error = str(e)
+                self.last_error = last_error
                 logger.error(f"❌ 章节分析异常(尝试 {attempt}/{max_retries}): {last_error}")
+
+                if self._is_non_retryable_ai_error(last_error):
+                    logger.error(f"❌ 第{chapter_number}章分析失败: {last_error}，该错误不可通过重试恢复")
+                    return None
                 
                 if attempt < max_retries:
                     wait_time = min(2 ** attempt, 10)
@@ -187,6 +214,7 @@ class PlotAnalyzer:
         
         # 不应该到达这里，但作为安全措施
         logger.error(f"❌ 第{chapter_number}章分析失败: {last_error}")
+        self.last_error = last_error
         return None
     
     def _format_existing_foreshadows(self, foreshadows: Optional[List[Dict[str, Any]]]) -> str:

--- a/backend/app/services/project_story_context.py
+++ b/backend/app/services/project_story_context.py
@@ -1,0 +1,77 @@
+"""Helpers for building compact project story context from outlines and chapters."""
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.chapter import Chapter
+from app.models.outline import Outline
+
+
+def _compact_text(text: str, max_len: int) -> str:
+    cleaned = " ".join((text or "").split())
+    if len(cleaned) <= max_len:
+        return cleaned
+    return f"{cleaned[:max_len].rstrip()}..."
+
+
+def _append_with_budget(lines: list[str], line: str, budget: int) -> bool:
+    current_len = sum(len(item) + 1 for item in lines)
+    if current_len + len(line) + 1 > budget:
+        return False
+    lines.append(line)
+    return True
+
+
+async def build_project_story_context(
+    db: AsyncSession,
+    project_id: str,
+    *,
+    max_chars: int = 12000,
+    outline_limit: int = 80,
+    chapter_limit: int = 80,
+) -> str:
+    """Build a bounded context from existing outlines and chapters for AI generation."""
+    lines: list[str] = []
+
+    outlines_result = await db.execute(
+        select(Outline)
+        .where(Outline.project_id == project_id)
+        .order_by(Outline.order_index.asc(), Outline.created_at.asc())
+        .limit(outline_limit)
+    )
+    outlines = outlines_result.scalars().all()
+
+    if outlines:
+        lines.append("【已有大纲摘要】")
+        for outline in outlines:
+            content = _compact_text(outline.content or outline.structure or "", 260)
+            if not content:
+                continue
+            order_label = outline.order_index if outline.order_index is not None else "-"
+            if not _append_with_budget(lines, f"- 第{order_label}条 {outline.title}: {content}", max_chars):
+                break
+
+    chapters_result = await db.execute(
+        select(Chapter)
+        .where(Chapter.project_id == project_id)
+        .order_by(Chapter.chapter_number.asc(), Chapter.created_at.asc())
+        .limit(chapter_limit)
+    )
+    chapters = chapters_result.scalars().all()
+
+    if chapters and sum(len(item) + 1 for item in lines) < max_chars:
+        if lines:
+            lines.append("")
+        lines.append("【已有章节摘要】")
+        for chapter in chapters:
+            source = chapter.summary or chapter.content or ""
+            content = _compact_text(source, 320)
+            if not content:
+                continue
+            line = f"- 第{chapter.chapter_number}章 {chapter.title}: {content}"
+            if not _append_with_budget(lines, line, max_chars):
+                break
+
+    if not lines:
+        return "【已有大纲和章节】暂无可用内容。"
+
+    return "\n".join(lines)

--- a/backend/app/services/prompt_service.py
+++ b/backend/app/services/prompt_service.py
@@ -28,6 +28,21 @@ class WritingStyleManager:
 class PromptService:
     """提示词模板管理"""
 
+    AI_DENOISING = """你是专业的中文小说文本编辑，请对下面文本进行润色和去 AI 味。
+
+处理目标：
+- 保留原意、事实、人物关系、设定和叙事视角。
+- 优化语句节奏，让表达更自然、更像人类作者写作。
+- 减少机械总结、工整排比、重复修辞和模板化表达。
+- 可以微调词序、断句、细节衔接，但不要扩写成新剧情。
+
+输出要求：
+- 只输出润色后的正文。
+- 不要解释，不要列清单，不要使用 Markdown。
+
+原文：
+{original_text}"""
+
     NOVEL_COVER_PROMPT_TEMPLATE = """创作一幅高质量小说封面插图，适用于竖版书籍封面。
 
 小说标题是：“{title}”。
@@ -2612,6 +2627,8 @@ class PromptService:
         Returns:
             格式化后的提示词
         """
+        if not template:
+            raise ValueError("提示词模板为空")
         try:
             return template.format(**kwargs)
         except KeyError as e:

--- a/backend/app/services/txt_parser_service.py
+++ b/backend/app/services/txt_parser_service.py
@@ -13,7 +13,10 @@ class TxtParserService:
     """TXT 解析服务（规则优先）"""
 
     STRONG_CHAPTER_PATTERNS = [
-        re.compile(r"^第[一二三四五六七八九十百千万零〇两\d]+[章节回卷集部篇].*$"),
+        re.compile(
+            r"^第[一二三四五六七八九十百千万零〇两\d]+"
+            r"(?:[章回卷集部篇].*|节(?:$|[\s　:：、.．\-—]).*)$"
+        ),
         re.compile(r"^chapter\s*\d+.*$", re.IGNORECASE),
         re.compile(r"^chap\.\s*\d+.*$", re.IGNORECASE),
     ]
@@ -55,16 +58,22 @@ class TxtParserService:
             return []
 
         lines = text.split("\n")
-        heading_indexes: list[int] = []
+        strong_heading_indexes: list[int] = []
+        weak_heading_indexes: list[int] = []
 
         for idx, line in enumerate(lines):
             stripped = line.strip()
             if not stripped:
                 continue
-            if self._is_strong_heading(stripped) or self._is_weak_heading(lines, idx):
-                heading_indexes.append(idx)
+            if self._is_strong_heading(stripped):
+                strong_heading_indexes.append(idx)
+            elif self._is_weak_heading(lines, idx):
+                weak_heading_indexes.append(idx)
 
-        # 去重并排序
+        # 标准章节标题足够多时，弱标题只会增加对白/短句误判。
+        heading_indexes = strong_heading_indexes if len(strong_heading_indexes) >= 2 else (
+            strong_heading_indexes + weak_heading_indexes
+        )
         heading_indexes = sorted(set(heading_indexes))
 
         # 如果一个标题都识别不到，走固定窗口兜底
@@ -126,6 +135,10 @@ class TxtParserService:
         if len(line) > 25:
             return False
         if re.search(r"[，。！？；：,.!?;:]", line):
+            return False
+        if line.startswith(("“", "‘", "\"", "'", "「", "『", "（", "(", "《")):
+            return False
+        if line.endswith(("”", "’", "\"", "'", "」", "』", "）", ")", "》")):
             return False
 
         prev_blank = idx == 0 or not lines[idx - 1].strip()

--- a/frontend/src/components/FloatingTaskPanel.tsx
+++ b/frontend/src/components/FloatingTaskPanel.tsx
@@ -153,6 +153,10 @@ export const FloatingTaskPanel: React.FC<FloatingTaskPanelProps> = ({
         return '大纲展开';
       case 'outline_batch_expand':
         return '批量大纲展开';
+      case 'outline_optimize':
+        return '大纲优化';
+      case 'character_optimize':
+        return '角色设定优化';
       case 'chapter_generate':
         return '章节生成';
       case 'chapter_batch':

--- a/frontend/src/components/PartialRegenerateModal.tsx
+++ b/frontend/src/components/PartialRegenerateModal.tsx
@@ -9,6 +9,7 @@ const { Text, Paragraph } = Typography;
 interface PartialRegenerateModalProps {
   visible: boolean;
   chapterId: string;
+  title?: string;
   selectedText: string;
   startPosition: number;
   endPosition: number;
@@ -26,6 +27,7 @@ type LengthMode = 'similar' | 'expand' | 'condense' | 'custom';
 export const PartialRegenerateModal: React.FC<PartialRegenerateModalProps> = ({
   visible,
   chapterId,
+  title = 'AI局部重写',
   selectedText,
   startPosition,
   endPosition,
@@ -42,6 +44,8 @@ export const PartialRegenerateModal: React.FC<PartialRegenerateModalProps> = ({
   const [hasGenerated, setHasGenerated] = useState(false);
   const [progress, setProgress] = useState(0);
   const [progressMessage, setProgressMessage] = useState('');
+  const [appliedStartPosition, setAppliedStartPosition] = useState(startPosition);
+  const [appliedEndPosition, setAppliedEndPosition] = useState(endPosition);
   const abortControllerRef = useRef<AbortController | null>(null);
   const generatedTextRef = useRef<HTMLDivElement>(null);
 
@@ -56,8 +60,10 @@ export const PartialRegenerateModal: React.FC<PartialRegenerateModalProps> = ({
       setHasGenerated(false);
       setProgress(0);
       setProgressMessage('');
+      setAppliedStartPosition(startPosition);
+      setAppliedEndPosition(endPosition);
     }
-  }, [visible, selectedText.length]);
+  }, [visible, selectedText, startPosition, endPosition]);
 
   // 自动滚动到底部
   useEffect(() => {
@@ -74,11 +80,16 @@ export const PartialRegenerateModal: React.FC<PartialRegenerateModalProps> = ({
 
     setIsGenerating(true);
     setGeneratedText('');
+    setHasGenerated(false);
     setProgress(0);
     setProgressMessage('准备生成...');
 
     // 创建 AbortController 用于取消请求
+    abortControllerRef.current?.abort();
     abortControllerRef.current = new AbortController();
+    let receivedText = false;
+    let handledError = false;
+    let accumulatedText = '';
 
     try {
       await chapterApi.partialRegenerateStream(
@@ -99,29 +110,59 @@ export const PartialRegenerateModal: React.FC<PartialRegenerateModalProps> = ({
             setProgressMessage(msg);
           },
           onChunk: (content) => {
-            setGeneratedText(prev => prev + content);
+            accumulatedText += content;
+            if (accumulatedText.trim()) {
+              receivedText = true;
+            }
+            setGeneratedText(accumulatedText);
           },
-          onResult: () => {
+          onResult: (data) => {
+            const finalText = typeof data?.new_text === 'string' ? data.new_text : '';
+            if (finalText.trim()) {
+              receivedText = true;
+              accumulatedText = finalText;
+              setGeneratedText(finalText);
+              setAppliedStartPosition(
+                typeof data.start_position === 'number' ? data.start_position : startPosition
+              );
+              setAppliedEndPosition(
+                typeof data.end_position === 'number' ? data.end_position : endPosition
+              );
+            }
             setProgress(100);
             setProgressMessage('生成完成');
-            setHasGenerated(true);
+            setHasGenerated(Boolean(finalText.trim()) || receivedText);
           },
           onError: (error) => {
+            handledError = true;
             console.error('SSE错误:', error);
             message.error(error || '生成过程中发生错误');
+            setHasGenerated(false);
+            setIsGenerating(false);
+            if (!accumulatedText.trim()) {
+              setGeneratedText('');
+            }
           },
           onComplete: () => {
             setIsGenerating(false);
-            setHasGenerated(true);
+            const hasUsableText = receivedText && accumulatedText.trim().length > 0;
+            setHasGenerated(hasUsableText);
+            if (!hasUsableText) {
+              message.warning('AI未返回可用重写内容，请重新生成');
+            }
           },
+          signal: abortControllerRef.current.signal,
         }
       );
     } catch (error) {
       console.error('生成失败:', error);
-      if ((error as Error).name !== 'AbortError') {
-        message.error('生成失败，请重试');
+      if ((error as Error).name !== 'AbortError' && !handledError) {
+        message.error((error as Error).message || '生成失败，请重试');
       }
       setIsGenerating(false);
+      setHasGenerated(false);
+    } finally {
+      abortControllerRef.current = null;
     }
   };
 
@@ -140,16 +181,17 @@ export const PartialRegenerateModal: React.FC<PartialRegenerateModalProps> = ({
       return;
     }
 
-    try {
-      // 调用后端应用更改
-      await chapterApi.applyPartialRegenerate(chapterId, {
-        new_text: generatedText,
-        start_position: startPosition,
-        end_position: endPosition,
-      });
+      try {
+        // 调用后端应用更改
+        await chapterApi.applyPartialRegenerate(chapterId, {
+          new_text: generatedText,
+          start_position: appliedStartPosition,
+          end_position: appliedEndPosition,
+          original_text: selectedText,
+        });
 
       message.success('已应用重写内容');
-      onApply(generatedText, startPosition, endPosition);
+      onApply(generatedText, appliedStartPosition, appliedEndPosition);
       onClose();
     } catch (error) {
       console.error('应用失败:', error);
@@ -180,7 +222,7 @@ export const PartialRegenerateModal: React.FC<PartialRegenerateModalProps> = ({
       title={
         <Space>
           <EditOutlined style={{ color: token.colorPrimary }} />
-          <span>AI局部重写</span>
+          <span>{title}</span>
         </Space>
       }
       open={visible}
@@ -192,8 +234,8 @@ export const PartialRegenerateModal: React.FC<PartialRegenerateModalProps> = ({
       keyboard={!isGenerating}
       footer={
         <Space style={{ width: '100%', justifyContent: 'flex-end' }}>
-          <Button onClick={handleCancel} disabled={isGenerating}>
-            取消
+          <Button onClick={handleCancel}>
+            {isGenerating ? '停止生成' : '取消'}
           </Button>
           {!hasGenerated ? (
             <Button

--- a/frontend/src/pages/Careers.tsx
+++ b/frontend/src/pages/Careers.tsx
@@ -340,7 +340,7 @@ export default function Careers() {
                                 setIsAIModalOpen(true);
                             }}
                         >
-                            AI生成新职业
+                            AI分析生成职业
                         </Button>
                         <Button
                             type="primary"
@@ -430,14 +430,14 @@ export default function Careers() {
 
             {/* AI生成对话框 */}
             <Modal
-                title="AI生成新职业（增量式）"
+                title="AI分析大纲/章节生成职业（增量式）"
                 open={isAIModalOpen}
                 onCancel={() => setIsAIModalOpen(false)}
                 footer={null}
             >
                 <Form form={aiForm} layout="vertical" onFinish={handleAIGenerate}>
                     <Paragraph type="secondary">
-                        AI将分析当前世界观和已有职业，智能生成新的补充职业。
+                        AI将分析当前世界观、已有职业、大纲和章节，智能生成新的补充职业。
                         <br />
                         💡 可以多次生成，逐步完善职业体系，不会替换已有职业。
                     </Paragraph>

--- a/frontend/src/pages/Chapters.tsx
+++ b/frontend/src/pages/Chapters.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { List, Button, Modal, Form, Input, Select, message, Empty, Space, Badge, Tag, Card, InputNumber, Alert, Radio, Descriptions, Collapse, Popconfirm, Pagination, theme } from 'antd';
-import { EditOutlined, FileTextOutlined, ThunderboltOutlined, LockOutlined, DownloadOutlined, SettingOutlined, FundOutlined, SyncOutlined, CheckCircleOutlined, CloseCircleOutlined, RocketOutlined, StopOutlined, InfoCircleOutlined, CaretRightOutlined, DeleteOutlined, BookOutlined, FormOutlined, PlusOutlined, ReadOutlined } from '@ant-design/icons';
+import { EditOutlined, FileTextOutlined, ThunderboltOutlined, LockOutlined, DownloadOutlined, SettingOutlined, FundOutlined, SyncOutlined, CheckCircleOutlined, CloseCircleOutlined, RocketOutlined, StopOutlined, InfoCircleOutlined, CaretRightOutlined, DeleteOutlined, BookOutlined, FormOutlined, PlusOutlined, ReadOutlined, SearchOutlined, FilterOutlined, ClearOutlined } from '@ant-design/icons';
 import { useStore } from '../store';
 import { eventBus } from '../store/eventBus';
 import { useChapterSync } from '../store/hooks';
@@ -46,6 +46,14 @@ const setCachedWordCount = (value: number): void => {
   }
 };
 
+const isAntdValidationError = (error: unknown): boolean => {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    Array.isArray((error as { errorFields?: unknown }).errorFields)
+  );
+};
+
 export default function Chapters() {
   const { currentProject, chapters, outlines, setCurrentChapter, setCurrentProject } = useStore();
   const [modal, contextHolder] = Modal.useModal();
@@ -75,8 +83,18 @@ export default function Chapters() {
 
   // 列表查询与分页状态
   const [chapterSearchKeyword, setChapterSearchKeyword] = useState('');
+  const [chapterStatusFilter, setChapterStatusFilter] = useState('all');
+  const [chapterAnalysisFilter, setChapterAnalysisFilter] = useState('all');
+  const [chapterContentFilter, setChapterContentFilter] = useState('all');
+  const [chapterOutlineFilter, setChapterOutlineFilter] = useState('all');
   const [chapterPage, setChapterPage] = useState(1);
   const [chapterPageSize, setChapterPageSize] = useState(20);
+
+  // 导出状态
+  const [exportModalVisible, setExportModalVisible] = useState(false);
+  const [exportRangeType, setExportRangeType] = useState<'all' | 'custom'>('all');
+  const [exporting, setExporting] = useState(false);
+  const [exportForm] = Form.useForm();
 
   // 阅读器状态
   const [readerVisible, setReaderVisible] = useState(false);
@@ -93,6 +111,7 @@ export default function Chapters() {
   const [selectionStartPosition, setSelectionStartPosition] = useState(0);
   const [selectionEndPosition, setSelectionEndPosition] = useState(0);
   const [partialRegenerateModalVisible, setPartialRegenerateModalVisible] = useState(false);
+  const [partialRegenerateTitle, setPartialRegenerateTitle] = useState('AI局部重写');
 
   // 单章节生成进度状态
   const [singleChapterProgress, setSingleChapterProgress] = useState(0);
@@ -132,28 +151,12 @@ export default function Chapters() {
       return;
     }
 
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) {
-      setPartialRegenerateToolbarVisible(false);
-      return;
-    }
-
-    const selectedText = selection.toString().trim();
-    
-    // 至少选中10个字符才显示工具栏
-    if (selectedText.length < 10) {
-      setPartialRegenerateToolbarVisible(false);
-      return;
-    }
-
-    // 检查选中是否在 TextArea 内
     const textArea = contentTextAreaRef.current?.resizableTextArea?.textArea;
     if (!textArea) {
       setPartialRegenerateToolbarVisible(false);
       return;
     }
-    
-    // 检查选中是否在 textarea 内（需要特殊处理，因为 textarea 的选中不会创建 range）
+
     if (document.activeElement !== textArea) {
       setPartialRegenerateToolbarVisible(false);
       return;
@@ -617,19 +620,64 @@ export default function Chapters() {
     return { sortedChapters: sorted };
   }, [chapters]);
 
+  const chapterOutlineOptions = useMemo(() => {
+    const optionMap = new Map<string, string>();
+    sortedChapters.forEach((chapter) => {
+      const key = chapter.outline_id || 'no_outline';
+      const label = chapter.outline_title || '未关联大纲';
+      if (!optionMap.has(key)) {
+        optionMap.set(key, label);
+      }
+    });
+
+    return Array.from(optionMap.entries()).map(([value, label]) => ({ value, label }));
+  }, [sortedChapters]);
+
   // 章节查询过滤（前端过滤，减少渲染压力）
   const filteredSortedChapters = useMemo(() => {
     const keyword = chapterSearchKeyword.trim().toLowerCase();
-    if (!keyword) return sortedChapters;
 
     return sortedChapters.filter((chapter) => {
-      return (
+      const matchesKeyword = !keyword || (
         String(chapter.chapter_number).includes(keyword) ||
         chapter.title.toLowerCase().includes(keyword) ||
         (chapter.outline_title || '').toLowerCase().includes(keyword)
       );
+
+      const matchesStatus = chapterStatusFilter === 'all' || chapter.status === chapterStatusFilter;
+
+      const task = analysisTasksMap[chapter.id];
+      const isAnalyzing = task?.status === 'pending' || task?.status === 'running';
+      const isAnalyzed = task?.status === 'completed';
+      const isAnalysisFailed = task?.status === 'failed';
+      const isUnanalyzed = !task || !task.has_task || task.status === 'none';
+      const matchesAnalysis =
+        chapterAnalysisFilter === 'all' ||
+        (chapterAnalysisFilter === 'completed' && isAnalyzed) ||
+        (chapterAnalysisFilter === 'unanalyzed' && isUnanalyzed) ||
+        (chapterAnalysisFilter === 'running' && isAnalyzing) ||
+        (chapterAnalysisFilter === 'failed' && isAnalysisFailed);
+
+      const hasContent = Boolean(chapter.content && chapter.content.trim() !== '');
+      const matchesContent =
+        chapterContentFilter === 'all' ||
+        (chapterContentFilter === 'has_content' && hasContent) ||
+        (chapterContentFilter === 'empty' && !hasContent);
+
+      const outlineKey = chapter.outline_id || 'no_outline';
+      const matchesOutline = chapterOutlineFilter === 'all' || outlineKey === chapterOutlineFilter;
+
+      return matchesKeyword && matchesStatus && matchesAnalysis && matchesContent && matchesOutline;
     });
-  }, [sortedChapters, chapterSearchKeyword]);
+  }, [
+    sortedChapters,
+    chapterSearchKeyword,
+    chapterStatusFilter,
+    chapterAnalysisFilter,
+    chapterContentFilter,
+    chapterOutlineFilter,
+    analysisTasksMap,
+  ]);
 
   // 分页后的扁平章节
   const pagedSortedChapters = useMemo(() => {
@@ -665,7 +713,15 @@ export default function Chapters() {
   // 搜索词或分页大小变化时重置到第一页
   useEffect(() => {
     setChapterPage(1);
-  }, [chapterSearchKeyword, chapterPageSize, currentProject?.outline_mode]);
+  }, [
+    chapterSearchKeyword,
+    chapterStatusFilter,
+    chapterAnalysisFilter,
+    chapterContentFilter,
+    chapterOutlineFilter,
+    chapterPageSize,
+    currentProject?.outline_mode,
+  ]);
 
   // 数据变化导致页码越界时自动纠正
   useEffect(() => {
@@ -727,6 +783,13 @@ export default function Chapters() {
       return task.status !== 'completed' && task.status !== 'pending' && task.status !== 'running';
     }).length;
   }, [sortedChapters, analysisTasksMap]);
+
+  const hasActiveChapterFilters =
+    chapterSearchKeyword.trim() !== '' ||
+    chapterStatusFilter !== 'all' ||
+    chapterAnalysisFilter !== 'all' ||
+    chapterContentFilter !== 'all' ||
+    chapterOutlineFilter !== 'all';
 
   if (!currentProject) return null;
 
@@ -1041,21 +1104,49 @@ export default function Chapters() {
       return;
     }
 
-    modal.confirm({
-      title: '导出项目章节',
-      content: `确定要将《${currentProject.title}》的所有章节导出为TXT文件吗？`,
-      centered: true,
-      okText: '确定导出',
-      cancelText: '取消',
-      onOk: () => {
-        try {
-          projectApi.exportProject(currentProject.id);
-          message.success('开始下载导出文件');
-        } catch {
-          message.error('导出失败，请重试');
-        }
-      },
+    const firstChapter = sortedChapters[0]?.chapter_number || 1;
+    const lastChapter = sortedChapters[sortedChapters.length - 1]?.chapter_number || firstChapter;
+    setExportRangeType('all');
+    exportForm.setFieldsValue({
+      rangeType: 'all',
+      start_chapter: firstChapter,
+      end_chapter: lastChapter,
+      exportMode: 'merged',
     });
+    setExportModalVisible(true);
+  };
+
+  const handleExportSubmit = async () => {
+    try {
+      const values = await exportForm.validateFields();
+      const startChapter = Number(values.start_chapter);
+      const endChapter = Number(values.end_chapter);
+
+      if (values.rangeType === 'custom' && startChapter > endChapter) {
+        message.warning('起始章节不能大于结束章节');
+        return;
+      }
+
+      setExporting(true);
+      await projectApi.exportProject(currentProject.id, {
+        start_chapter: values.rangeType === 'custom' ? startChapter : undefined,
+        end_chapter: values.rangeType === 'custom' ? endChapter : undefined,
+        split: values.exportMode === 'split',
+      });
+      setExportModalVisible(false);
+      message.success(values.exportMode === 'split' ? '开始下载分章ZIP' : '开始下载TXT文件');
+    } catch (error) {
+      if (isAntdValidationError(error)) {
+        return;
+      }
+      if (error instanceof Error && error.message) {
+        message.error(`导出失败：${error.message}`);
+      } else if (error) {
+        message.error('导出失败，请重试');
+      }
+    } finally {
+      setExporting(false);
+    }
   };
 
   const handleShowAnalysis = (chapterId: string) => {
@@ -1898,6 +1989,46 @@ export default function Chapters() {
   // 打开局部重写弹窗
   const handleOpenPartialRegenerate = () => {
     setPartialRegenerateToolbarVisible(false);
+    setPartialRegenerateTitle('AI精准重写选中段落');
+    setPartialRegenerateModalVisible(true);
+  };
+
+  const handleOpenSelectedTextRegenerate = () => {
+    const textArea = contentTextAreaRef.current?.resizableTextArea?.textArea;
+    if (!textArea) {
+      message.warning('请先打开章节内容编辑器');
+      return;
+    }
+
+    const start = textArea.selectionStart;
+    const end = textArea.selectionEnd;
+    const selectedText = textArea.value.substring(start, end);
+
+    if (start === end || selectedText.trim().length < 10) {
+      message.warning('请先在章节内容中选中至少10个字');
+      return;
+    }
+
+    setSelectedTextForRegenerate(selectedText);
+    setSelectionStartPosition(start);
+    setSelectionEndPosition(end);
+    setPartialRegenerateToolbarVisible(false);
+    setPartialRegenerateTitle('AI精准重写选中段落');
+    setPartialRegenerateModalVisible(true);
+  };
+
+  const handleOpenFullChapterRegenerate = () => {
+    const content = String(editorForm.getFieldValue('content') || '');
+    if (!content.trim()) {
+      message.warning('章节内容为空，无法重写');
+      return;
+    }
+
+    setSelectedTextForRegenerate(content);
+    setSelectionStartPosition(0);
+    setSelectionEndPosition(content.length);
+    setPartialRegenerateToolbarVisible(false);
+    setPartialRegenerateTitle('AI提示词重写整章');
     setPartialRegenerateModalVisible(true);
   };
 
@@ -1931,9 +2062,9 @@ export default function Chapters() {
         borderBottom: `1px solid ${token.colorBorderSecondary}`,
         display: 'flex',
         flexDirection: isMobile ? 'column' : 'row',
-        gap: isMobile ? 12 : 0,
+        gap: isMobile ? 12 : 16,
         justifyContent: 'space-between',
-        alignItems: isMobile ? 'stretch' : 'center'
+        alignItems: isMobile ? 'stretch' : 'flex-start'
       }}>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
           <h2 style={{ margin: 0, fontSize: isMobile ? 18 : 24 }}>
@@ -1949,60 +2080,141 @@ export default function Chapters() {
               : '细化模式：章节可在大纲页面展开'}
           </Tag>
         </div>
-        <Space direction={isMobile ? 'vertical' : 'horizontal'} style={{ width: isMobile ? '100%' : 'auto' }}>
-          <Input.Search
-            allowClear
-            placeholder="搜索章节（序号/标题/大纲）"
-            value={chapterSearchKeyword}
-            onChange={(e) => setChapterSearchKeyword(e.target.value)}
-            style={{ width: isMobile ? '100%' : 280 }}
-          />
-          {currentProject.outline_mode === 'one-to-many' && (
+        <div style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: isMobile ? 'stretch' : 'flex-end',
+          gap: 8,
+          width: isMobile ? '100%' : 'auto',
+          minWidth: isMobile ? 0 : 520,
+        }}>
+          <Space
+            wrap
+            size={8}
+            style={{
+              width: '100%',
+              justifyContent: isMobile ? 'flex-start' : 'flex-end',
+              alignItems: 'center',
+            }}
+          >
+            <Input
+              allowClear
+              prefix={<SearchOutlined />}
+              placeholder="搜索章节（序号/标题/大纲）"
+              value={chapterSearchKeyword}
+              onChange={(e) => setChapterSearchKeyword(e.target.value)}
+              style={{ width: isMobile ? '100%' : 300 }}
+            />
+            {currentProject.outline_mode === 'one-to-many' && (
+              <Button
+                icon={<PlusOutlined />}
+                onClick={showManualCreateChapterModal}
+                block={isMobile}
+              >
+                手动创建
+              </Button>
+            )}
             <Button
-              icon={<PlusOutlined />}
-              onClick={showManualCreateChapterModal}
+              type="primary"
+              icon={<ThunderboltOutlined />}
+              onClick={handleBatchAnalyzeUnanalyzed}
+              loading={batchAnalyzingUnanalyzed}
+              disabled={chapters.length === 0 || batchAnalyzableChapterCount === 0}
               block={isMobile}
-              size={isMobile ? 'middle' : 'middle'}
+              style={{ background: token.colorWarning, borderColor: token.colorWarning }}
+              title={batchAnalyzableChapterCount === 0 ? '暂无可一键分析章节' : `可一键分析 ${batchAnalyzableChapterCount} 章`}
             >
-              手动创建
+              一键分析{batchAnalyzableChapterCount > 0 ? ` (${batchAnalyzableChapterCount})` : ''}
             </Button>
-          )}
-          <Button
-            type="primary"
-            icon={<ThunderboltOutlined />}
-            onClick={handleBatchAnalyzeUnanalyzed}
-            loading={batchAnalyzingUnanalyzed}
-            disabled={chapters.length === 0 || batchAnalyzableChapterCount === 0}
-            block={isMobile}
-            size={isMobile ? 'middle' : 'middle'}
-            style={{ background: token.colorWarning, borderColor: token.colorWarning }}
-            title={batchAnalyzableChapterCount === 0 ? '暂无可一键分析章节' : `可一键分析 ${batchAnalyzableChapterCount} 章`}
+            <Button
+              type="primary"
+              icon={<RocketOutlined />}
+              onClick={handleOpenBatchGenerate}
+              disabled={chapters.length === 0 || batchGenerating}
+              loading={batchGenerating}
+              block={isMobile}
+              style={batchGenerating ? {} : { background: token.colorInfo, borderColor: token.colorInfo }}
+            >
+              {batchGenerating ? '生成中...' : '批量生成'}
+            </Button>
+            <Button
+              type="default"
+              icon={<DownloadOutlined />}
+              onClick={handleExport}
+              disabled={chapters.length === 0}
+              block={isMobile}
+            >
+              导出章节
+            </Button>
+          </Space>
+          <Space
+            wrap
+            size={8}
+            style={{
+              width: '100%',
+              justifyContent: isMobile ? 'flex-start' : 'flex-end',
+              alignItems: 'center',
+            }}
           >
-            一键分析{batchAnalyzableChapterCount > 0 ? ` (${batchAnalyzableChapterCount})` : ''}
-          </Button>
-          <Button
-            type="primary"
-            icon={<RocketOutlined />}
-            onClick={handleOpenBatchGenerate}
-            disabled={chapters.length === 0 || batchGenerating}
-            loading={batchGenerating}
-            block={isMobile}
-            size={isMobile ? 'middle' : 'middle'}
-            style={batchGenerating ? {} : { background: token.colorInfo, borderColor: token.colorInfo }}
-          >
-            {batchGenerating ? '生成中...' : '批量生成'}
-          </Button>
-          <Button
-            type="default"
-            icon={<DownloadOutlined />}
-            onClick={handleExport}
-            disabled={chapters.length === 0}
-            block={isMobile}
-            size={isMobile ? 'middle' : 'middle'}
-          >
-            导出为TXT
-          </Button>
-        </Space>
+            <Select
+              value={chapterStatusFilter}
+              onChange={setChapterStatusFilter}
+              style={{ width: isMobile ? 'calc(50% - 4px)' : 116 }}
+              suffixIcon={<FilterOutlined />}
+              options={[
+                { value: 'all', label: '全部状态' },
+                { value: 'draft', label: '草稿' },
+                { value: 'pending', label: '待处理' },
+                { value: 'writing', label: '创作中' },
+                { value: 'completed', label: '已完成' },
+              ]}
+            />
+            <Select
+              value={chapterAnalysisFilter}
+              onChange={setChapterAnalysisFilter}
+              style={{ width: isMobile ? 'calc(50% - 4px)' : 116 }}
+              options={[
+                { value: 'all', label: '全部分析' },
+                { value: 'completed', label: '已分析' },
+                { value: 'unanalyzed', label: '未分析' },
+                { value: 'running', label: '分析中' },
+                { value: 'failed', label: '分析失败' },
+              ]}
+            />
+            <Select
+              value={chapterContentFilter}
+              onChange={setChapterContentFilter}
+              style={{ width: isMobile ? 'calc(50% - 4px)' : 116 }}
+              options={[
+                { value: 'all', label: '全部正文' },
+                { value: 'has_content', label: '有正文' },
+                { value: 'empty', label: '空章节' },
+              ]}
+            />
+            <Select
+              value={chapterOutlineFilter}
+              onChange={setChapterOutlineFilter}
+              style={{ width: isMobile ? 'calc(50% - 4px)' : 168 }}
+              options={[
+                { value: 'all', label: '全部大纲' },
+                ...chapterOutlineOptions,
+              ]}
+            />
+            <Button
+              icon={<ClearOutlined />}
+              disabled={!hasActiveChapterFilters}
+              onClick={() => {
+                setChapterSearchKeyword('');
+                setChapterStatusFilter('all');
+                setChapterAnalysisFilter('all');
+                setChapterContentFilter('all');
+                setChapterOutlineFilter('all');
+              }}
+            >
+              重置
+            </Button>
+          </Space>
+        </div>
       </div>
 
 
@@ -2436,6 +2648,66 @@ export default function Chapters() {
       )}
 
       <Modal
+        title="导出项目章节"
+        open={exportModalVisible}
+        onCancel={() => setExportModalVisible(false)}
+        onOk={handleExportSubmit}
+        confirmLoading={exporting}
+        okText="开始导出"
+        cancelText="取消"
+        centered
+        width={isMobile ? 'calc(100vw - 32px)' : 560}
+      >
+        <Form
+          form={exportForm}
+          layout="vertical"
+          initialValues={{ rangeType: 'all', exportMode: 'merged' }}
+        >
+          <Form.Item label="导出范围" name="rangeType">
+            <Radio.Group
+              optionType="button"
+              buttonStyle="solid"
+              onChange={(event) => setExportRangeType(event.target.value)}
+              options={[
+                { value: 'all', label: '全部章节' },
+                { value: 'custom', label: '指定范围' },
+              ]}
+            />
+          </Form.Item>
+
+          {exportRangeType === 'custom' && (
+            <Space size={12} style={{ width: '100%' }} align="start">
+              <Form.Item
+                label="起始章节"
+                name="start_chapter"
+                rules={[{ required: true, message: '请输入起始章节' }]}
+              >
+                <InputNumber min={1} precision={0} style={{ width: 160 }} addonBefore="第" addonAfter="章" />
+              </Form.Item>
+              <Form.Item
+                label="结束章节"
+                name="end_chapter"
+                rules={[{ required: true, message: '请输入结束章节' }]}
+              >
+                <InputNumber min={1} precision={0} style={{ width: 160 }} addonBefore="第" addonAfter="章" />
+              </Form.Item>
+            </Space>
+          )}
+
+          <Form.Item label="导出方式" name="exportMode">
+            <Radio.Group
+              optionType="button"
+              buttonStyle="solid"
+              options={[
+                { value: 'merged', label: '合并TXT' },
+                { value: 'split', label: '分章ZIP' },
+              ]}
+            />
+          </Form.Item>
+        </Form>
+      </Modal>
+
+      <Modal
         title={editingId ? '编辑章节信息' : '添加章节'}
         open={isModalOpen}
         onCancel={() => setIsModalOpen(false)}
@@ -2683,13 +2955,36 @@ export default function Chapters() {
             </Form.Item>
           </div>
 
-          <Form.Item label="章节内容" name="content">
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12, marginBottom: 8 }}>
+            <span style={{ color: token.colorTextSecondary }}>章节内容</span>
+            <Space wrap size={8}>
+              <Button
+                size="small"
+                icon={<ThunderboltOutlined />}
+                onClick={handleOpenFullChapterRegenerate}
+                disabled={isGenerating}
+              >
+                提示词重写整章
+              </Button>
+              <Button
+                size="small"
+                icon={<EditOutlined />}
+                onClick={handleOpenSelectedTextRegenerate}
+                disabled={isGenerating}
+              >
+                精准重写选中段落
+              </Button>
+            </Space>
+          </div>
+
+          <Form.Item name="content">
             <TextArea
               ref={contentTextAreaRef}
               rows={isMobile ? 12 : 20}
               placeholder="开始写作..."
               style={{ fontFamily: 'monospace', fontSize: isMobile ? 12 : 14 }}
               disabled={isGenerating}
+              onSelect={handleTextSelection}
             />
           </Form.Item>
 
@@ -3016,6 +3311,7 @@ export default function Chapters() {
         <PartialRegenerateModal
           visible={partialRegenerateModalVisible}
           chapterId={editingId}
+          title={partialRegenerateTitle}
           selectedText={selectedTextForRegenerate}
           startPosition={selectionStartPosition}
           endPosition={selectionEndPosition}

--- a/frontend/src/pages/Characters.tsx
+++ b/frontend/src/pages/Characters.tsx
@@ -1,15 +1,18 @@
 import { useState, useEffect, useRef } from 'react';
 import { Button, Modal, Form, Input, Select, message, Row, Col, Empty, Tabs, Divider, Typography, Space, InputNumber, Checkbox, theme } from 'antd';
-import { ThunderboltOutlined, UserOutlined, TeamOutlined, PlusOutlined, ExportOutlined, ImportOutlined, DownloadOutlined } from '@ant-design/icons';
+import { ThunderboltOutlined, UserOutlined, TeamOutlined, PlusOutlined, ExportOutlined, ImportOutlined, DownloadOutlined, HighlightOutlined } from '@ant-design/icons';
 import { useStore } from '../store';
+import { eventBus } from '../store/eventBus';
 import { useCharacterSync } from '../store/hooks';
 import { charactersPageGridConfig } from '../components/CardStyles';
 import { CharacterCard } from '../components/CharacterCard';
 import { SSELoadingOverlay } from '../components/SSELoadingOverlay';
 import type { Character, ApiError } from '../types';
-import { characterApi } from '../services/api';
+import { characterApi, polishApi } from '../services/api';
 import { SSEPostClient } from '../utils/sseClient';
 import api from '../services/api';
+import { pollTaskUntilComplete } from '../services/backgroundTaskService';
+import { extractJsonObject } from '../utils/jsonExtract';
 
 const { Title } = Typography;
 const { TextArea } = Input;
@@ -93,6 +96,128 @@ interface CharacterUpdateData {
   color?: string;
 }
 
+type CharacterSettingsSource = Partial<Character> & Partial<CharacterFormValues>;
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function parseLabeledSections(text: string, labelMap: Record<string, string[]>): Record<string, string> {
+  const allLabels = Object.values(labelMap).flat().map(escapeRegExp).join('|');
+  const sections: Record<string, string> = {};
+
+  Object.entries(labelMap).forEach(([field, labels]) => {
+    for (const label of labels) {
+      const pattern = new RegExp(
+        `(?:^|\\n)\\s*${escapeRegExp(label)}\\s*[：:]\\s*([\\s\\S]*?)(?=\\n\\s*(?:${allLabels})\\s*[：:]|$)`,
+        'i'
+      );
+      const match = text.match(pattern);
+      const value = match?.[1]?.trim();
+      if (value) {
+        sections[field] = value;
+        break;
+      }
+    }
+  });
+
+  return sections;
+}
+
+function getStringField(data: Record<string, unknown> | null, key: string): string | undefined {
+  const value = data?.[key];
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function getCharacterOptimizeInstruction(isOrganization?: boolean) {
+  if (isOrganization) {
+    return [
+      '你是小说设定编辑，请优化组织/势力设定。',
+      '只优化表达、层次和可读性，不改变既有事实、名称、阵营、世界观和时间线。',
+      '严格只输出 JSON，不要 Markdown，不要解释。',
+      'JSON 字段：organization_purpose、motto、background。'
+    ].join('\n');
+  }
+
+  return [
+    '你是小说设定编辑，请优化角色设定。',
+    '只优化表达、层次和可读性，不改变既有事实、姓名、定位、年龄、性别、阵营、能力来源和时间线。',
+    '严格只输出 JSON，不要 Markdown，不要解释。',
+    'JSON 字段：personality、appearance、background。'
+  ].join('\n');
+}
+
+function buildCharacterOptimizeSource(character: CharacterSettingsSource) {
+  if (character.is_organization) {
+    return JSON.stringify({
+      type: 'organization',
+      name: character.name || '',
+      organization_type: character.organization_type || '',
+      organization_purpose: character.organization_purpose || '',
+      power_level: character.power_level,
+      location: character.location || '',
+      motto: character.motto || '',
+      color: character.color || '',
+      background: character.background || ''
+    }, null, 2);
+  }
+
+  return JSON.stringify({
+    type: 'character',
+    name: character.name || '',
+    role_type: character.role_type || '',
+    age: character.age || '',
+    gender: character.gender || '',
+    personality: character.personality || '',
+    appearance: character.appearance || '',
+    background: character.background || ''
+  }, null, 2);
+}
+
+function parseOptimizedCharacterSettings(polishedText: string, isOrganization?: boolean): CharacterUpdateData {
+  const json = extractJsonObject(polishedText);
+
+  if (isOrganization) {
+    const fromJson: CharacterUpdateData = {
+      organization_purpose: getStringField(json, 'organization_purpose'),
+      motto: getStringField(json, 'motto'),
+      background: getStringField(json, 'background')
+    };
+    const labeled = parseLabeledSections(polishedText, {
+      organization_purpose: ['组织目的', '宗旨目标'],
+      motto: ['格言', '口号', '格言/口号'],
+      background: ['组织背景', '背景']
+    });
+
+    return {
+      organization_purpose: fromJson.organization_purpose || labeled.organization_purpose,
+      motto: fromJson.motto || labeled.motto,
+      background: fromJson.background || labeled.background
+    };
+  }
+
+  const fromJson: CharacterUpdateData = {
+    personality: getStringField(json, 'personality'),
+    appearance: getStringField(json, 'appearance'),
+    background: getStringField(json, 'background')
+  };
+  const labeled = parseLabeledSections(polishedText, {
+    personality: ['性格特点', '性格'],
+    appearance: ['外貌描写', '外貌'],
+    background: ['角色背景', '背景']
+  });
+
+  return {
+    personality: fromJson.personality || labeled.personality,
+    appearance: fromJson.appearance || labeled.appearance,
+    background: fromJson.background || labeled.background
+  };
+}
+
+function hasOptimizedFields(data: CharacterUpdateData) {
+  return Object.values(data).some(value => typeof value === 'string' && value.trim());
+}
+
 export default function Characters() {
   const { token } = theme.useToken();
   const { currentProject, characters } = useStore();
@@ -112,7 +237,10 @@ export default function Characters() {
   const [subCareers, setSubCareers] = useState<Career[]>([]);
   const [selectedCharacters, setSelectedCharacters] = useState<string[]>([]);
   const [isImportModalOpen, setIsImportModalOpen] = useState(false);
+  const [isOptimizingCharacter, setIsOptimizingCharacter] = useState(false);
+  const [isOptimizingBatch, setIsOptimizingBatch] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const characterOptimizePollCancelRef = useRef<ReturnType<typeof pollTaskUntilComplete> | null>(null);
 
   const {
     refreshCharacters,
@@ -126,6 +254,13 @@ export default function Characters() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentProject?.id]);
+
+  useEffect(() => {
+    return () => {
+      characterOptimizePollCancelRef.current?.();
+      characterOptimizePollCancelRef.current = null;
+    };
+  }, []);
   const [modal, contextHolder] = Modal.useModal();
 
   const fetchCareers = async () => {
@@ -344,6 +479,153 @@ export default function Characters() {
       console.error('更新失败:', error);
       message.error('更新失败');
     }
+  };
+
+  const optimizeCharacterSettings = async (source: CharacterSettingsSource) => {
+    const result = await polishApi.polishText({
+      original_text: buildCharacterOptimizeSource(source),
+      instruction: getCharacterOptimizeInstruction(source.is_organization),
+      temperature: 0.6,
+    });
+
+    const updateData = parseOptimizedCharacterSettings(
+      result.polished_text || '',
+      source.is_organization
+    );
+
+    if (!hasOptimizedFields(updateData)) {
+      throw new Error('AI返回格式无法识别');
+    }
+
+    return updateData;
+  };
+
+  const handleOptimizeEditingCharacter = async () => {
+    if (!editingCharacter) return;
+
+    try {
+      setIsOptimizingCharacter(true);
+      const values = editForm.getFieldsValue();
+      const updateData = await optimizeCharacterSettings({
+        ...editingCharacter,
+        ...values,
+        is_organization: editingCharacter.is_organization
+      });
+
+      editForm.setFieldsValue(updateData);
+      message.success('AI优化结果已填入表单，请检查后保存');
+    } catch (error) {
+      console.error('AI优化设定失败:', error);
+      message.error(error instanceof Error ? error.message : 'AI优化设定失败');
+    } finally {
+      setIsOptimizingCharacter(false);
+    }
+  };
+
+  const handleBatchOptimizeSelected = () => {
+    if (selectedCharacters.length === 0) {
+      message.warning('请至少选择一个角色或组织');
+      return;
+    }
+
+    const selectedItems = characters.filter(character => selectedCharacters.includes(character.id));
+    if (selectedItems.length === 0) {
+      message.warning('未找到已选择的角色或组织');
+      return;
+    }
+
+    modal.confirm({
+      title: '批量优化角色设定',
+      centered: true,
+      width: 560,
+      content: (
+        <div>
+          <p>将使用现有 AI 润色流程优化已选的 {selectedItems.length} 个角色/组织设定。</p>
+          <p style={{ color: token.colorTextSecondary, marginBottom: 0 }}>
+            会保留名称、身份、阵营、能力来源等既有事实，优化结果将直接保存到数据库。
+          </p>
+        </div>
+      ),
+      okText: '开始优化',
+      cancelText: '取消',
+      onOk: async () => {
+        const messageKey = 'batch-character-optimize';
+
+        if (!currentProject?.id) {
+          message.warning('请先选择项目');
+          return;
+        }
+
+        setIsOptimizingBatch(true);
+        characterOptimizePollCancelRef.current?.();
+        characterOptimizePollCancelRef.current = null;
+        try {
+          message.loading({
+            key: messageKey,
+            content: `正在提交 ${selectedItems.length} 个角色/组织优化任务...`,
+            duration: 0
+          });
+
+          const response = await polishApi.optimizeCharactersBackground({
+            project_id: currentProject.id,
+            character_ids: selectedItems.map(character => character.id),
+            temperature: 0.6,
+          });
+
+          message.success({
+            key: messageKey,
+            content: '角色设定优化任务已提交，可在右下角后台任务中查看或取消',
+            duration: 3
+          });
+          eventBus.emit('background-task-created');
+
+          characterOptimizePollCancelRef.current = pollTaskUntilComplete(
+            response.task_id,
+            (status) => {
+              if (status.status === 'pending' || status.status === 'running') {
+                message.loading({
+                  key: messageKey,
+                  content: status.status_message || `角色设定优化中 ${Math.round(status.progress)}%`,
+                  duration: 0
+                });
+              }
+            },
+            (status) => {
+              characterOptimizePollCancelRef.current = null;
+              void (async () => {
+                await refreshCharacters();
+                setSelectedCharacters([]);
+                message.success({
+                  key: messageKey,
+                  content: status.status_message || '角色设定优化完成',
+                  duration: 3
+                });
+                setIsOptimizingBatch(false);
+                eventBus.emit('background-task-created');
+              })();
+            },
+            (error) => {
+              characterOptimizePollCancelRef.current = null;
+              message.error({
+                key: messageKey,
+                content: error || '角色设定优化任务失败',
+                duration: 4
+              });
+              setIsOptimizingBatch(false);
+              eventBus.emit('background-task-created');
+            }
+          );
+        } catch (error) {
+          console.error('提交角色设定优化任务失败:', error);
+          message.error({
+            key: messageKey,
+            content: error instanceof Error ? error.message : '提交角色设定优化任务失败',
+            duration: 4
+          });
+          setIsOptimizingBatch(false);
+        }
+      }
+    });
   };
 
   const handleDeleteCharacterWrapper = (id: string) => {
@@ -691,13 +973,25 @@ export default function Characters() {
             导入
           </Button>
           {selectedCharacters.length > 0 && (
-            <Button
-              icon={<ExportOutlined />}
-              onClick={handleExportSelected}
-              size={isMobile ? 'small' : 'middle'}
-            >
-              批量导出 ({selectedCharacters.length})
-            </Button>
+            <>
+              <Button
+                type="dashed"
+                icon={<HighlightOutlined />}
+                onClick={handleBatchOptimizeSelected}
+                loading={isOptimizingBatch}
+                disabled={isOptimizingCharacter}
+                size={isMobile ? 'small' : 'middle'}
+              >
+                批量优化设定 ({selectedCharacters.length})
+              </Button>
+              <Button
+                icon={<ExportOutlined />}
+                onClick={handleExportSelected}
+                size={isMobile ? 'small' : 'middle'}
+              >
+                批量导出 ({selectedCharacters.length})
+              </Button>
+            </>
           )}
         </Space>
       </div>
@@ -936,18 +1230,28 @@ export default function Characters() {
           setEditingCharacter(null);
         }}
         footer={
-          <Space style={{ width: '100%', justifyContent: 'flex-end' }}>
-            <Button onClick={() => {
-              setIsEditModalOpen(false);
-              editForm.resetFields();
-              setEditingCharacter(null);
-            }}>
-              取消
+          <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, width: '100%', flexWrap: 'wrap' }}>
+            <Button
+              icon={<HighlightOutlined />}
+              onClick={handleOptimizeEditingCharacter}
+              loading={isOptimizingCharacter}
+              disabled={!editingCharacter}
+            >
+              {editingCharacter?.is_organization ? 'AI优化组织设定' : 'AI优化角色设定'}
             </Button>
-            <Button type="primary" onClick={() => editForm.submit()}>
-              保存
-            </Button>
-          </Space>
+            <Space style={{ marginLeft: 'auto' }}>
+              <Button onClick={() => {
+                setIsEditModalOpen(false);
+                editForm.resetFields();
+                setEditingCharacter(null);
+              }}>
+                取消
+              </Button>
+              <Button type="primary" onClick={() => editForm.submit()}>
+                保存
+              </Button>
+            </Space>
+          </div>
         }
         centered
         width={isMobile ? '100%' : 700}

--- a/frontend/src/pages/Organizations.tsx
+++ b/frontend/src/pages/Organizations.tsx
@@ -1,10 +1,16 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 import { Card, Table, Tag, Button, Space, message, Modal, Form, Select, InputNumber, Input, Descriptions, Drawer, theme } from 'antd';
-import { PlusOutlined, UserOutlined, EditOutlined, DeleteOutlined, UnorderedListOutlined, BankOutlined } from '@ant-design/icons';
+import { PlusOutlined, UserOutlined, EditOutlined, DeleteOutlined, UnorderedListOutlined, BankOutlined, ThunderboltOutlined, HighlightOutlined, ReloadOutlined } from '@ant-design/icons';
 import { useStore } from '../store';
 import { useCharacterSync } from '../store/hooks';
+import { characterApi, polishApi } from '../services/api';
+import { SSEPostClient } from '../utils/sseClient';
+import { SSELoadingOverlay } from '../components/SSELoadingOverlay';
+import { extractJsonObject } from '../utils/jsonExtract';
 import axios from 'axios';
+
+const { TextArea } = Input;
 
 interface Organization {
   id: string;
@@ -39,6 +45,34 @@ interface Character {
   is_organization: boolean;
 }
 
+interface OrganizationFormValues {
+  name: string;
+  organization_type?: string;
+  organization_purpose?: string;
+  background?: string;
+  power_level?: number;
+  location?: string;
+  motto?: string;
+  color?: string;
+}
+
+interface OrganizationGenerateValues {
+  name?: string;
+  organization_type?: string;
+  background?: string;
+  requirements?: string;
+}
+
+const getStringField = (data: Record<string, unknown> | null, key: string): string | undefined => {
+  const value = data?.[key];
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+};
+
+const getNumberField = (data: Record<string, unknown> | null, key: string): number | undefined => {
+  const value = data?.[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+};
+
 export default function Organizations() {
   const { projectId } = useParams<{ projectId: string }>();
   const { currentProject } = useStore();
@@ -51,8 +85,15 @@ export default function Organizations() {
   const [isAddMemberModalOpen, setIsAddMemberModalOpen] = useState(false);
   const [isEditMemberModalOpen, setIsEditMemberModalOpen] = useState(false);
   const [isEditOrgModalOpen, setIsEditOrgModalOpen] = useState(false);
+  const [isCreateOrgModalOpen, setIsCreateOrgModalOpen] = useState(false);
   const [editingMember, setEditingMember] = useState<OrganizationMember | null>(null);
+  const [isGeneratingOrg, setIsGeneratingOrg] = useState(false);
+  const [isOptimizingOrg, setIsOptimizingOrg] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [progressMessage, setProgressMessage] = useState('');
   const [form] = Form.useForm();
+  const [createOrgForm] = Form.useForm<OrganizationFormValues>();
+  const [generateOrgForm] = Form.useForm<OrganizationGenerateValues>();
   const [editMemberForm] = Form.useForm();
   const [editOrgForm] = Form.useForm();
   const [isMobile, setIsMobile] = useState(window.innerWidth <= 768);
@@ -116,6 +157,139 @@ export default function Organizations() {
   const handleSelectOrganization = (org: Organization) => {
     setSelectedOrg(org);
     loadMembers(org.id);
+  };
+
+  const handleCreateOrganization = async (values: OrganizationFormValues) => {
+    if (!projectId) return;
+
+    try {
+      await characterApi.createCharacter({
+        project_id: projectId,
+        name: values.name,
+        is_organization: true,
+        role_type: 'supporting',
+        organization_type: values.organization_type,
+        organization_purpose: values.organization_purpose,
+        background: values.background,
+        power_level: values.power_level ?? 50,
+        location: values.location,
+        motto: values.motto,
+        color: values.color,
+      });
+      message.success('组织创建成功');
+      setIsCreateOrgModalOpen(false);
+      createOrgForm.resetFields();
+      await refreshCharacters();
+      await loadOrganizations();
+    } catch (error) {
+      message.error('创建组织失败');
+      console.error(error);
+    }
+  };
+
+  const handleGenerateOrganization = async (values: OrganizationGenerateValues) => {
+    if (!projectId) return;
+
+    try {
+      setIsGeneratingOrg(true);
+      setProgress(0);
+      setProgressMessage('准备生成组织...');
+
+      const client = new SSEPostClient(
+        '/api/organizations/generate-stream',
+        {
+          project_id: projectId,
+          name: values.name,
+          organization_type: values.organization_type,
+          background: values.background,
+          requirements: values.requirements,
+        },
+        {
+          onProgress: (msg, prog) => {
+            setProgress(prog);
+            setProgressMessage(msg);
+          },
+          onError: (error) => {
+            message.error(`生成失败: ${error}`);
+          },
+          onComplete: () => {
+            setProgress(100);
+            setProgressMessage('生成完成！');
+          },
+        }
+      );
+
+      await client.connect();
+      message.success('AI生成组织成功');
+      Modal.destroyAll();
+      generateOrgForm.resetFields();
+      await refreshCharacters();
+      await loadOrganizations();
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : 'AI生成组织失败');
+    } finally {
+      setTimeout(() => {
+        setIsGeneratingOrg(false);
+        setProgress(0);
+        setProgressMessage('');
+      }, 500);
+    }
+  };
+
+  const handleOptimizeOrganization = async () => {
+    if (!selectedOrg) return;
+
+    try {
+      setIsOptimizingOrg(true);
+      const character = await characterApi.getCharacter(selectedOrg.character_id);
+      const source = JSON.stringify({
+        type: 'organization',
+        name: selectedOrg.name,
+        organization_type: selectedOrg.type || '',
+        organization_purpose: selectedOrg.purpose || '',
+        power_level: selectedOrg.power_level,
+        location: selectedOrg.location || '',
+        motto: selectedOrg.motto || '',
+        color: selectedOrg.color || '',
+        background: character.background || '',
+      }, null, 2);
+      const result = await polishApi.polishText({
+        original_text: source,
+        instruction: [
+          '你是小说设定编辑，请分析并优化组织/势力设定。',
+          '只优化表达、层次和可读性，不改变既有事实、名称、阵营、世界观和时间线。',
+          '严格只输出 JSON，不要 Markdown，不要解释。',
+          'JSON 字段：organization_purpose、motto、background、location、color、power_level。'
+        ].join('\n'),
+        temperature: 0.6,
+      });
+      const parsed = extractJsonObject(result.polished_text || '');
+      const updateData = {
+        organization_purpose: getStringField(parsed, 'organization_purpose'),
+        motto: getStringField(parsed, 'motto'),
+        background: getStringField(parsed, 'background'),
+        location: getStringField(parsed, 'location'),
+        color: getStringField(parsed, 'color'),
+        power_level: getNumberField(parsed, 'power_level'),
+      };
+      const filtered = Object.fromEntries(
+        Object.entries(updateData).filter(([, value]) => value !== undefined)
+      );
+
+      if (Object.keys(filtered).length === 0) {
+        message.warning('AI返回格式无法识别');
+        return;
+      }
+
+      await characterApi.updateCharacter(selectedOrg.character_id, filtered);
+      message.success('组织设定已优化');
+      await refreshCharacters();
+      await loadOrganizations();
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : 'AI优化组织失败');
+    } finally {
+      setIsOptimizingOrg(false);
+    }
   };
 
   const handleAddMember = async (values: Record<string, unknown>) => {
@@ -302,6 +476,75 @@ export default function Organizations() {
     c => !c.is_organization && !members.some(m => m.character_id === c.id)
   );
 
+  const renderToolbar = () => (
+    <Space wrap size={isMobile ? 8 : 'middle'}>
+      {isMobile && organizations.length > 0 && (
+        <Button
+          icon={<UnorderedListOutlined />}
+          onClick={() => setOrgListVisible(true)}
+        >
+          组织列表
+        </Button>
+      )}
+      <Button
+        type="primary"
+        icon={<PlusOutlined />}
+        onClick={() => {
+          createOrgForm.setFieldsValue({ power_level: 50 });
+          setIsCreateOrgModalOpen(true);
+        }}
+      >
+        手动添加
+      </Button>
+      <Button
+        type="dashed"
+        icon={<ThunderboltOutlined />}
+        loading={isGeneratingOrg}
+        onClick={() => {
+          generateOrgForm.resetFields();
+          modal.confirm({
+            title: 'AI分析大纲/章节生成组织',
+            width: 600,
+            centered: true,
+            content: (
+              <Form form={generateOrgForm} layout="vertical" style={{ marginTop: 16 }}>
+                <Form.Item label="组织名称" name="name">
+                  <Input placeholder="可选，留空则由 AI 根据已有大纲和章节生成" />
+                </Form.Item>
+                <Form.Item label="组织类型" name="organization_type">
+                  <Input placeholder="如：军方、公司、学院、秘密结社" />
+                </Form.Item>
+                <Form.Item label="背景设定" name="background">
+                  <TextArea rows={3} placeholder="简要描述组织背景和环境" />
+                </Form.Item>
+                <Form.Item label="其他要求" name="requirements">
+                  <TextArea rows={2} placeholder="其他特殊要求" />
+                </Form.Item>
+              </Form>
+            ),
+            okText: '生成',
+            cancelText: '取消',
+            onOk: async () => {
+              const values = await generateOrgForm.validateFields();
+              await handleGenerateOrganization(values);
+            },
+          });
+        }}
+      >
+        AI分析生成组织
+      </Button>
+      <Button
+        icon={<ReloadOutlined />}
+        onClick={() => {
+          loadOrganizations();
+          loadCharacters();
+        }}
+      >
+        刷新
+      </Button>
+    </Space>
+  );
+
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
       {contextHolder}
@@ -313,11 +556,27 @@ export default function Organizations() {
           marginBottom: 16,
           borderBottom: `1px solid ${token.colorBorderSecondary}`
         }}>
-          <h2 style={{ margin: 0, fontSize: 24 }}>
-            <BankOutlined style={{ marginRight: 8 }} />
-            组织管理
-          </h2>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 16 }}>
+            <h2 style={{ margin: 0, fontSize: 24 }}>
+              <BankOutlined style={{ marginRight: 8 }} />
+              组织管理
+            </h2>
+            {renderToolbar()}
+          </div>
         </div>
+      )}
+
+      {isMobile && (
+        <Card size="small" style={{ marginBottom: 8 }}>
+          <Space direction="vertical" style={{ width: '100%' }} size="middle">
+            <Space>
+              <BankOutlined />
+              <span style={{ fontSize: 16, fontWeight: 600 }}>组织管理</span>
+              <Tag color="blue">{currentProject?.title}</Tag>
+            </Space>
+            {renderToolbar()}
+          </Space>
+        </Card>
       )}
       
       <div style={{
@@ -417,43 +676,11 @@ export default function Organizations() {
         {!selectedOrg ? (
           <Card style={{ height: '100%' }}>
             <div style={{ textAlign: 'center', padding: '100px 20px', color: token.colorTextTertiary }}>
-              {isMobile && organizations.length > 0 && (
-                <Button
-                  type="primary"
-                  icon={<UnorderedListOutlined />}
-                  onClick={() => setOrgListVisible(true)}
-                  style={{ marginBottom: 20 }}
-                >
-                  选择组织
-                </Button>
-              )}
               <div>请选择一个组织查看详情</div>
             </div>
           </Card>
         ) : (
           <>
-            {/* 工具栏 - 移动端显示项目标题和组织列表按钮 */}
-            {isMobile && (
-              <Card size="small" style={{ marginBottom: 8 }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                  <Space>
-                    <BankOutlined />
-                    <span style={{ fontSize: 14, fontWeight: 600 }}>
-                      组织管理
-                    </span>
-                    <Tag color="blue">{currentProject?.title}</Tag>
-                  </Space>
-                  <Button
-                    icon={<UnorderedListOutlined />}
-                    onClick={() => setOrgListVisible(true)}
-                    size="small"
-                  >
-                    列表
-                  </Button>
-                </div>
-              </Card>
-            )}
-
             {/* 内容区域 */}
             <div style={{
               flex: 1,
@@ -470,22 +697,33 @@ export default function Organizations() {
                   title="组织详情"
                   size="small"
                   extra={
-                    <Button
-                      type="link"
-                      size="small"
-                      icon={<EditOutlined />}
-                      onClick={() => {
-                        editOrgForm.setFieldsValue({
-                          power_level: selectedOrg.power_level,
-                          location: selectedOrg.location,
-                          motto: selectedOrg.motto,
-                          color: selectedOrg.color
-                        });
-                        setIsEditOrgModalOpen(true);
-                      }}
-                    >
-                      编辑
-                    </Button>
+                    <Space>
+                      <Button
+                        type="link"
+                        size="small"
+                        icon={<HighlightOutlined />}
+                        loading={isOptimizingOrg}
+                        onClick={handleOptimizeOrganization}
+                      >
+                        AI优化
+                      </Button>
+                      <Button
+                        type="link"
+                        size="small"
+                        icon={<EditOutlined />}
+                        onClick={() => {
+                          editOrgForm.setFieldsValue({
+                            power_level: selectedOrg.power_level,
+                            location: selectedOrg.location,
+                            motto: selectedOrg.motto,
+                            color: selectedOrg.color
+                          });
+                          setIsEditOrgModalOpen(true);
+                        }}
+                      >
+                        编辑
+                      </Button>
+                    </Space>
                   }
                 >
                   <Descriptions column={isMobile ? 1 : 2} size="small">
@@ -841,6 +1079,69 @@ export default function Organizations() {
           </Form.Item>
         </Form>
       </Modal>
+
+      {/* 手动创建组织模态框 */}
+      <Modal
+        title="手动添加组织"
+        open={isCreateOrgModalOpen}
+        onCancel={() => {
+          setIsCreateOrgModalOpen(false);
+          createOrgForm.resetFields();
+        }}
+        footer={null}
+        centered={!isMobile}
+        width={isMobile ? '100%' : 620}
+        style={isMobile ? { top: 0, paddingBottom: 0, maxWidth: '100vw' } : undefined}
+        styles={isMobile ? { body: { maxHeight: 'calc(100vh - 110px)', overflowY: 'auto' } } : undefined}
+      >
+        <Form
+          form={createOrgForm}
+          layout="vertical"
+          onFinish={handleCreateOrganization}
+          initialValues={{ power_level: 50 }}
+        >
+          <Form.Item
+            name="name"
+            label="组织名称"
+            rules={[{ required: true, message: '请输入组织名称' }]}
+          >
+            <Input placeholder="如：舰载机联络处、帝国总参谋部" />
+          </Form.Item>
+          <Form.Item name="organization_type" label="组织类型">
+            <Input placeholder="如：军方、公司、学院、秘密结社" />
+          </Form.Item>
+          <Form.Item name="organization_purpose" label="组织目的">
+            <TextArea rows={3} placeholder="这个组织的目标、职能或存在意义" />
+          </Form.Item>
+          <Form.Item name="background" label="组织背景">
+            <TextArea rows={3} placeholder="组织历史、来源、矛盾或与主线的关系" />
+          </Form.Item>
+          <Form.Item name="power_level" label="势力等级">
+            <InputNumber min={0} max={100} style={{ width: '100%' }} />
+          </Form.Item>
+          <Form.Item name="location" label="所在地">
+            <Input placeholder="组织常驻地点或活动范围" />
+          </Form.Item>
+          <Form.Item name="motto" label="格言/口号">
+            <Input placeholder="可选" />
+          </Form.Item>
+          <Form.Item name="color" label="代表颜色">
+            <Input placeholder="如：深蓝、银白、黑金" />
+          </Form.Item>
+          <Form.Item style={{ marginBottom: 0 }}>
+            <Space style={{ width: '100%', justifyContent: 'flex-end' }}>
+              <Button onClick={() => setIsCreateOrgModalOpen(false)}>取消</Button>
+              <Button type="primary" htmlType="submit">保存组织</Button>
+            </Space>
+          </Form.Item>
+        </Form>
+      </Modal>
+
+      <SSELoadingOverlay
+        loading={isGeneratingOrg}
+        progress={progress}
+        message={progressMessage}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/Outline.tsx
+++ b/frontend/src/pages/Outline.tsx
@@ -1,13 +1,15 @@
-﻿import { useState, useEffect, useMemo } from 'react';
+﻿import { useState, useEffect, useMemo, useRef } from 'react';
+import type { ChangeEvent, CSSProperties } from 'react';
 import { Button, List, Modal, Form, Input, message, Empty, Space, Popconfirm, Card, Select, Radio, Tag, InputNumber, Tabs, Pagination, theme } from 'antd';
-import { EditOutlined, DeleteOutlined, ThunderboltOutlined, BranchesOutlined, AppstoreAddOutlined, CheckCircleOutlined, ExclamationCircleOutlined, PlusOutlined, FileTextOutlined } from '@ant-design/icons';
+import type { FormInstance } from 'antd';
+import { EditOutlined, DeleteOutlined, ThunderboltOutlined, BranchesOutlined, AppstoreAddOutlined, CheckCircleOutlined, ExclamationCircleOutlined, PlusOutlined, FileTextOutlined, HighlightOutlined } from '@ant-design/icons';
 import { useStore } from '../store';
 import { eventBus } from '../store/eventBus';
-import { getProjectTasks, type TaskStatus } from '../services/backgroundTaskService';
+import { getProjectTasks, pollTaskUntilComplete, type TaskStatus } from '../services/backgroundTaskService';
 import { useOutlineSync } from '../store/hooks';
 import { generateOutlineBackground } from '../services/backgroundTaskService';
-import { outlineApi, chapterApi, projectApi, characterApi } from '../services/api';
-import type { ApiError, Character } from '../types';
+import { outlineApi, chapterApi, projectApi, characterApi, polishApi } from '../services/api';
+import type { ApiError, Character, Outline as OutlineItem } from '../types';
 
 // 大纲生成请求数据类型
 interface OutlineGenerateRequestData {
@@ -23,6 +25,25 @@ interface OutlineGenerateRequestData {
   plot_stage: 'development' | 'climax' | 'ending';
   model?: string;
   provider?: string;
+}
+
+interface GenerateFormValues {
+  theme?: string;
+  chapter_count?: number;
+  narrative_perspective?: string;
+  requirements?: string;
+  provider?: string;
+  model?: string;
+  mode?: 'auto' | 'new' | 'continue';
+  story_direction?: string;
+  plot_stage?: 'development' | 'climax' | 'ending';
+  keep_existing?: boolean;
+}
+
+type PolishableOutlineField = 'story_direction' | 'requirements';
+
+interface OutlineOptimizeFormValues {
+  scope: 'all' | 'filtered' | 'page';
 }
 
 // 角色/组织条目类型（新格式）
@@ -105,6 +126,108 @@ function getOutlinePreview(content: string, maxLength = 120): { text: string; tr
 
 const { TextArea } = Input;
 
+interface PolishableTextAreaProps {
+  form: FormInstance<GenerateFormValues>;
+  name: PolishableOutlineField;
+  label: string;
+  rows: number;
+  placeholder: string;
+  value?: string;
+  id?: string;
+  onChange?: (event: ChangeEvent<HTMLTextAreaElement>) => void;
+}
+
+function PolishableTextArea({
+  form,
+  name,
+  label,
+  rows,
+  placeholder,
+  value,
+  id,
+  onChange,
+}: PolishableTextAreaProps) {
+  const [isPolishing, setIsPolishing] = useState(false);
+  const { token } = theme.useToken();
+
+  const handlePolish = async () => {
+    const currentValue = String(form.getFieldValue(name) || '').trim();
+    if (!currentValue) {
+      message.warning(`请先填写${label}`);
+      return;
+    }
+
+    const closeLoading = message.loading(`正在润色${label}...`, 0);
+    try {
+      setIsPolishing(true);
+      const selectedModel = form.getFieldValue('model');
+      const selectedProvider = form.getFieldValue('provider');
+      const result = await polishApi.polishText({
+        original_text: currentValue,
+        model: selectedModel || undefined,
+        provider: selectedProvider || undefined,
+        temperature: 0.7,
+      });
+
+      const polishedText = result.polished_text?.trim();
+      if (!polishedText) {
+        message.warning('润色结果为空，请稍后重试');
+        return;
+      }
+
+      form.setFieldsValue({ [name]: polishedText });
+      message.success(`${label}已润色`);
+    } catch (error) {
+      console.error(`${label}润色失败:`, error);
+      message.error(`${label}润色失败`);
+    } finally {
+      closeLoading();
+      setIsPolishing(false);
+    }
+  };
+
+  const textAreaStyle: CSSProperties = {
+    paddingRight: 44,
+  };
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <TextArea
+        id={id}
+        rows={rows}
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+        style={textAreaStyle}
+      />
+      <Button
+        type="text"
+        shape="circle"
+        size="small"
+        icon={<HighlightOutlined />}
+        loading={isPolishing}
+        aria-label={`润色${label}`}
+        title={`润色${label}`}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          void handlePolish();
+        }}
+        style={{
+          position: 'absolute',
+          top: 8,
+          right: 8,
+          zIndex: 1,
+          color: token.colorPrimary,
+          background: token.colorBgElevated,
+          border: `1px solid ${token.colorBorderSecondary}`,
+          boxShadow: token.boxShadowTertiary,
+        }}
+      />
+    </div>
+  );
+}
+
 export default function Outline() {
   const { currentProject, outlines, setCurrentProject } = useStore();
   const [isGenerating, setIsGenerating] = useState(false);
@@ -113,10 +236,14 @@ export default function Outline() {
   const [expansionForm] = Form.useForm();
   const [modalApi, contextHolder] = Modal.useModal();
   const [batchExpansionForm] = Form.useForm();
+  const [outlineOptimizeForm] = Form.useForm<OutlineOptimizeFormValues>();
   const [manualCreateForm] = Form.useForm();
   const [isMobile, setIsMobile] = useState(window.innerWidth <= 768);
   const [isExpanding, setIsExpanding] = useState(false);
+  const [isOptimizingOutlines, setIsOptimizingOutlines] = useState(false);
+  const [optimizingOutlineId, setOptimizingOutlineId] = useState<string | null>(null);
   const [projectCharacters, setProjectCharacters] = useState<Array<{ label: string; value: string }>>([]);
+  const outlineOptimizePollCancelRef = useRef<ReturnType<typeof pollTaskUntilComplete> | null>(null);
   const { token } = theme.useToken();
   const alphaColor = (color: string, alpha: number) =>
     `color-mix(in srgb, ${color} ${(alpha * 100).toFixed(0)}%, transparent)`;
@@ -134,6 +261,13 @@ export default function Outline() {
 
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      outlineOptimizePollCancelRef.current?.();
+      outlineOptimizePollCancelRef.current = null;
+    };
   }, []);
 
   // 大纲查询与分页状态
@@ -500,19 +634,6 @@ export default function Outline() {
     }
   };
 
-  interface GenerateFormValues {
-    theme?: string;
-    chapter_count?: number;
-    narrative_perspective?: string;
-    requirements?: string;
-    provider?: string;
-    model?: string;
-    mode?: 'auto' | 'new' | 'continue';
-    story_direction?: string;
-    plot_stage?: 'development' | 'climax' | 'ending';
-    keep_existing?: boolean;
-  }
-
   const handleGenerate = async (values: GenerateFormValues) => {
     try {
       setIsGenerating(true);
@@ -696,7 +817,10 @@ export default function Outline() {
                         name="story_direction"
                         tooltip="告诉AI你希望故事接下来如何发展"
                       >
-                        <TextArea
+                        <PolishableTextArea
+                          form={generateForm}
+                          name="story_direction"
+                          label="故事发展方向"
                           rows={3}
                           placeholder="例如：主角遇到新的挑战、引入新角色、揭示关键秘密等..."
                         />
@@ -742,7 +866,13 @@ export default function Outline() {
                   </Form.Item>
 
                   <Form.Item label="其他要求" name="requirements">
-                    <TextArea rows={2} placeholder="其他特殊要求（可选）" />
+                    <PolishableTextArea
+                      form={generateForm}
+                      name="requirements"
+                      label="其他要求"
+                      rows={2}
+                      placeholder="其他特殊要求（可选）"
+                    />
                   </Form.Item>
 
                 </>
@@ -1446,6 +1576,170 @@ export default function Outline() {
     });
   };
 
+  const submitOutlineOptimizeTask = async (targets: OutlineItem[], singleOutline?: OutlineItem) => {
+    if (!currentProject?.id) {
+      message.warning('请先选择项目');
+      return;
+    }
+
+    if (targets.length === 0) {
+      message.warning('没有可优化的大纲');
+      return;
+    }
+
+    const messageKey = singleOutline ? `outline-optimize-${singleOutline.id}` : 'batch-outline-optimize';
+    const resetLoadingState = () => {
+      if (singleOutline) {
+        setOptimizingOutlineId(null);
+      } else {
+        setIsOptimizingOutlines(false);
+      }
+    };
+
+    if (singleOutline) {
+      setOptimizingOutlineId(singleOutline.id);
+    } else {
+      setIsOptimizingOutlines(true);
+    }
+    outlineOptimizePollCancelRef.current?.();
+    outlineOptimizePollCancelRef.current = null;
+
+    try {
+      message.loading({
+        key: messageKey,
+        content: singleOutline
+          ? `正在提交《${singleOutline.title}》优化任务...`
+          : `正在提交 ${targets.length} 条大纲优化任务...`,
+        duration: 0
+      });
+
+      const response = await polishApi.optimizeOutlinesBackground({
+        project_id: currentProject.id,
+        outline_ids: targets.map(outline => outline.id),
+        temperature: 0.6,
+      });
+
+      message.success({
+        key: messageKey,
+        content: '大纲优化任务已提交，可在右下角后台任务中查看或取消',
+        duration: 3
+      });
+      eventBus.emit('background-task-created');
+
+      outlineOptimizePollCancelRef.current = pollTaskUntilComplete(
+        response.task_id,
+        (status: TaskStatus) => {
+          if (status.status === 'pending' || status.status === 'running') {
+            message.loading({
+              key: messageKey,
+              content: status.status_message || `大纲优化中 ${Math.round(status.progress)}%`,
+              duration: 0
+            });
+          }
+        },
+        (status: TaskStatus) => {
+          outlineOptimizePollCancelRef.current = null;
+          void (async () => {
+            await refreshOutlines();
+            message.success({
+              key: messageKey,
+              content: status.status_message || '大纲优化完成',
+              duration: 3
+            });
+            resetLoadingState();
+            eventBus.emit('background-task-created');
+          })();
+        },
+        (error: string) => {
+          outlineOptimizePollCancelRef.current = null;
+          message.error({
+            key: messageKey,
+            content: error || '大纲优化任务失败',
+            duration: 4
+          });
+          resetLoadingState();
+          eventBus.emit('background-task-created');
+        }
+      );
+    } catch (error) {
+      console.error('提交大纲优化任务失败:', error);
+      message.error({
+        key: messageKey,
+        content: error instanceof Error ? error.message : '提交大纲优化任务失败',
+        duration: 4
+      });
+      resetLoadingState();
+    }
+  };
+
+  const handleOptimizeSingleOutline = async (outline: OutlineItem) => {
+    await submitOutlineOptimizeTask([outline], outline);
+  };
+
+  const runBatchOptimizeOutlines = async (targets: OutlineItem[]) => {
+    await submitOutlineOptimizeTask(targets);
+  };
+
+  const showOptimizeOutlinesModal = () => {
+    if (outlines.length === 0) {
+      message.warning('没有可优化的大纲');
+      return;
+    }
+
+    outlineOptimizeForm.setFieldsValue({
+      scope: outlineSearchKeyword.trim() ? 'filtered' : 'all'
+    });
+
+    modalApi.confirm({
+      title: 'AI优化已有大纲',
+      width: 560,
+      centered: true,
+      content: (
+        <Form
+          form={outlineOptimizeForm}
+          layout="vertical"
+          style={{ marginTop: 16 }}
+        >
+          <Form.Item
+            label="优化范围"
+            name="scope"
+            rules={[{ required: true, message: '请选择优化范围' }]}
+          >
+            <Radio.Group>
+              <Space direction="vertical">
+                <Radio value="all">全部大纲（{outlines.length} 条）</Radio>
+                <Radio value="filtered" disabled={filteredOutlines.length === 0}>
+                  当前筛选结果（{filteredOutlines.length} 条）
+                </Radio>
+                <Radio value="page">当前页（{pagedOutlines.length} 条）</Radio>
+              </Space>
+            </Radio.Group>
+          </Form.Item>
+          <div style={{ color: token.colorTextSecondary, fontSize: 13 }}>
+            使用现有后台任务流程优化表达与可执行性，不改变章节编号、标题和核心设定；提交后可在右下角后台任务中查看或取消。
+          </div>
+        </Form>
+      ),
+      okText: '开始优化',
+      cancelText: '取消',
+      onOk: async () => {
+        const values = await outlineOptimizeForm.validateFields();
+        const targets = values.scope === 'page'
+          ? pagedOutlines
+          : values.scope === 'filtered'
+            ? filteredOutlines
+            : sortedOutlines;
+
+        if (targets.length === 0) {
+          message.warning('当前范围内没有可优化的大纲');
+          return;
+        }
+
+        await runBatchOptimizeOutlines(targets);
+      }
+    });
+  };
+
   return (
     <>
       {contextHolder}
@@ -1501,6 +1795,17 @@ export default function Outline() {
             >
               {isMobile ? 'AI生成/续写' : 'AI生成/续写大纲'}
             </Button>
+            {outlines.length > 0 && (
+              <Button
+                icon={<HighlightOutlined />}
+                onClick={showOptimizeOutlinesModal}
+                loading={isOptimizingOutlines}
+                disabled={isGenerating}
+                block={isMobile}
+              >
+                {isMobile ? '优化大纲' : 'AI优化已有大纲'}
+              </Button>
+            )}
             {outlines.length > 0 && currentProject?.outline_mode === 'one-to-many' && (
               <Button
                 icon={<AppstoreAddOutlined />}
@@ -2271,6 +2576,15 @@ export default function Outline() {
                               展开
                             </Button>
                           )}
+                          <Button
+                            icon={<HighlightOutlined />}
+                            onClick={() => handleOptimizeSingleOutline(item)}
+                            loading={optimizingOutlineId === item.id}
+                            disabled={isOptimizingOutlines}
+                            size={isMobile ? 'middle' : 'small'}
+                          >
+                            AI优化
+                          </Button>
                           <Button
                             icon={<EditOutlined />}
                             onClick={() => handleOpenEditModal(item.id)}

--- a/frontend/src/pages/Relationships.tsx
+++ b/frontend/src/pages/Relationships.tsx
@@ -1,11 +1,13 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { Card, Table, Tag, Button, Space, message, Modal, Form, Select, Slider, Input, Tabs, AutoComplete, theme } from 'antd';
-import { PlusOutlined, ApartmentOutlined, UserOutlined, EditOutlined } from '@ant-design/icons';
+import { Card, Table, Tag, Button, Space, message, Modal, Form, Select, Slider, Input, Tabs, AutoComplete, theme, InputNumber, Typography } from 'antd';
+import { PlusOutlined, ApartmentOutlined, UserOutlined, EditOutlined, ThunderboltOutlined } from '@ant-design/icons';
 import { useStore } from '../store';
 import axios from 'axios';
+import SSEProgressModal from '../components/SSEProgressModal';
 
 const { TextArea } = Input;
+const { Paragraph } = Typography;
 
 interface Relationship {
   id: string;
@@ -41,14 +43,20 @@ export default function Relationships() {
   const [characters, setCharacters] = useState<Character[]>([]);
   const [loading, setLoading] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isAIModalOpen, setIsAIModalOpen] = useState(false);
   const [isEditMode, setIsEditMode] = useState(false);
   const [editingRelationship, setEditingRelationship] = useState<Relationship | null>(null);
   const [form] = Form.useForm();
+  const [aiForm] = Form.useForm();
   const [modal, contextHolder] = Modal.useModal();
   const { token } = theme.useToken();
   const [isMobile, setIsMobile] = useState(window.innerWidth <= 768);
   const [pageSize, setPageSize] = useState(10);
   const [currentPage, setCurrentPage] = useState(1);
+  const [aiGenerating, setAiGenerating] = useState(false);
+  const [aiProgress, setAiProgress] = useState(0);
+  const [aiMessage, setAiMessage] = useState('');
+  const relationshipGenerateAbortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
     const handleResize = () => {
@@ -65,6 +73,13 @@ export default function Relationships() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectId]);
+
+  useEffect(() => {
+    return () => {
+      relationshipGenerateAbortRef.current?.abort();
+      relationshipGenerateAbortRef.current = null;
+    };
+  }, []);
 
   const loadData = async () => {
     setLoading(true);
@@ -171,6 +186,93 @@ export default function Relationships() {
         }
       }
     });
+  };
+
+  const handleAIGenerateRelationships = async (values: {
+    relationship_count: number;
+    requirements?: string;
+  }) => {
+    setIsAIModalOpen(false);
+    setAiGenerating(true);
+    setAiProgress(0);
+    setAiMessage('开始分析大纲和章节...');
+    relationshipGenerateAbortRef.current?.abort();
+    const abortController = new AbortController();
+    relationshipGenerateAbortRef.current = abortController;
+
+    try {
+      const response = await fetch('/api/relationships/generate-stream', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+        body: JSON.stringify({
+          project_id: projectId || '',
+          relationship_count: values.relationship_count,
+          requirements: values.requirements?.trim() || '',
+        }),
+        signal: abortController.signal,
+      });
+
+      if (!response.ok || !response.body) {
+        message.error(`请求失败: ${response.status}`);
+        return;
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+          try {
+            const data = JSON.parse(line.slice(6));
+            if (data.type === 'progress') {
+              setAiProgress(data.progress || 0);
+              setAiMessage(data.message || '');
+            } else if (data.type === 'done') {
+              message.success('AI关系生成完成');
+              loadData();
+            } else if (data.type === 'error') {
+              message.error(data.error || data.message || '生成失败');
+              return;
+            }
+          } catch {
+            // Ignore raw generation chunks.
+          }
+        }
+      }
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        message.info('已取消关系生成');
+      } else {
+        message.error(error instanceof Error ? error.message : '启动生成失败');
+      }
+    } finally {
+      if (relationshipGenerateAbortRef.current === abortController) {
+        relationshipGenerateAbortRef.current = null;
+      }
+      setAiGenerating(false);
+      setAiProgress(0);
+      setAiMessage('');
+    }
+  };
+
+  const handleCancelAIGeneration = () => {
+    relationshipGenerateAbortRef.current?.abort();
+    relationshipGenerateAbortRef.current = null;
+    setAiGenerating(false);
+    setAiProgress(0);
+    setAiMessage('');
   };
 
   const getCharacterName = (id: string) => {
@@ -320,7 +422,20 @@ export default function Relationships() {
           </Space>
         }
         extra={
-          <Space>
+          <Space wrap>
+            <Button
+              icon={<ThunderboltOutlined />}
+              onClick={() => {
+                aiForm.resetFields();
+                aiForm.setFieldsValue({ relationship_count: 8 });
+                setIsAIModalOpen(true);
+              }}
+              disabled={characters.filter(c => !c.is_organization).length < 2}
+              loading={aiGenerating}
+              size={isMobile ? 'small' : 'middle'}
+            >
+              {isMobile ? 'AI分析' : 'AI分析生成关系'}
+            </Button>
             <Button
               onClick={() => projectId && navigate(`/project/${projectId}/relationships-graph`)}
               size={isMobile ? 'small' : 'middle'}
@@ -412,6 +527,38 @@ export default function Relationships() {
           ]}
         />
       </Card>
+
+      <Modal
+        title="AI分析大纲/章节生成关系"
+        open={isAIModalOpen}
+        onCancel={() => setIsAIModalOpen(false)}
+        footer={null}
+        centered={!isMobile}
+        width={isMobile ? '100%' : 560}
+      >
+        <Form form={aiForm} layout="vertical" onFinish={handleAIGenerateRelationships}>
+          <Paragraph type="secondary">
+            AI会读取当前项目已有角色、大纲和章节，提取尚未入库的角色关系，不会覆盖已有关系。
+          </Paragraph>
+          <Form.Item label="本次生成关系数量" name="relationship_count" initialValue={8}>
+            <InputNumber min={1} max={50} style={{ width: '100%' }} />
+          </Form.Item>
+          <Form.Item label="额外要求" name="requirements">
+            <TextArea
+              rows={3}
+              placeholder="可选，例如：优先补全敌对关系、上下级关系，忽略只出现一次的路人关系。"
+            />
+          </Form.Item>
+          <Form.Item>
+            <Space style={{ width: '100%', justifyContent: 'flex-end' }}>
+              <Button onClick={() => setIsAIModalOpen(false)}>取消</Button>
+              <Button type="primary" icon={<ThunderboltOutlined />} htmlType="submit">
+                开始分析
+              </Button>
+            </Space>
+          </Form.Item>
+        </Form>
+      </Modal>
 
       <Modal
         title={isEditMode ? '编辑关系' : '添加关系'}
@@ -536,6 +683,13 @@ export default function Relationships() {
           </Form.Item>
         </Form>
       </Modal>
+      <SSEProgressModal
+        visible={aiGenerating}
+        progress={aiProgress}
+        message={aiMessage}
+        title="AI分析生成关系中..."
+        onCancel={handleCancelAIGeneration}
+      />
       </div>
     </>
   );

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -384,8 +384,37 @@ export const projectApi = {
     window.URL.revokeObjectURL(url);
   },
 
-  exportProject: (id: string) => {
-    window.open(`/api/projects/${id}/export`, '_blank');
+  exportProject: async (id: string, options?: {
+    start_chapter?: number;
+    end_chapter?: number;
+    split?: boolean;
+  }) => {
+    const response = await axios.get(`/api/projects/${id}/export`, {
+      params: options,
+      responseType: 'blob',
+      withCredentials: true,
+    });
+
+    const contentDisposition = response.headers['content-disposition'];
+    let filename = options?.split ? 'chapters.zip' : 'chapters.txt';
+    if (contentDisposition) {
+      const utf8Match = /filename\*=UTF-8''(.+)/.exec(contentDisposition);
+      const basicMatch = /filename="?([^";]+)"?/.exec(contentDisposition);
+      if (utf8Match?.[1]) {
+        filename = decodeURIComponent(utf8Match[1]);
+      } else if (basicMatch?.[1]) {
+        filename = basicMatch[1];
+      }
+    }
+
+    const url = window.URL.createObjectURL(new Blob([response.data]));
+    const link = document.createElement('a');
+    link.href = url;
+    link.setAttribute('download', filename);
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    window.URL.revokeObjectURL(url);
   },
 
   // 导出项目数据为JSON
@@ -772,6 +801,7 @@ export const chapterApi = {
     new_text: string;
     start_position: number;
     end_position: number;
+    original_text?: string;
   }) =>
     api.post<unknown, {
       success: boolean;
@@ -923,6 +953,30 @@ export const polishApi = {
 
   polishBatch: (texts: string[]) =>
     api.post<unknown, { polished_texts: string[] }>('/polish/batch', { texts }),
+
+  optimizeOutlinesBackground: (data: {
+    project_id: string;
+    outline_ids?: string[];
+    provider?: string;
+    model?: string;
+    temperature?: number;
+  }) =>
+    api.post<unknown, { task_id: string; task_type: string; status: string; message: string }>(
+      '/polish/outlines/background',
+      data,
+    ),
+
+  optimizeCharactersBackground: (data: {
+    project_id: string;
+    character_ids: string[];
+    provider?: string;
+    model?: string;
+    temperature?: number;
+  }) =>
+    api.post<unknown, { task_id: string; task_type: string; status: string; message: string }>(
+      '/polish/characters/background',
+      data,
+    ),
 };
 export const inspirationApi = {
   // 生成选项建议

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -511,8 +511,12 @@ export interface GenerateCharacterRequest {
 }
 
 export interface PolishTextRequest {
-  text: string;
-  style?: string;
+  original_text: string;
+  project_id?: string;
+  provider?: string;
+  model?: string;
+  temperature?: number;
+  instruction?: string;
 }
 
 // 向导API响应类型

--- a/frontend/src/utils/jsonExtract.ts
+++ b/frontend/src/utils/jsonExtract.ts
@@ -1,0 +1,19 @@
+export function extractJsonObject(text: string): Record<string, unknown> | null {
+  const cleaned = text.trim()
+    .replace(/^```(?:json)?\s*/i, '')
+    .replace(/```$/i, '')
+    .trim();
+
+  try {
+    return JSON.parse(cleaned) as Record<string, unknown>;
+  } catch {
+    const match = cleaned.match(/\{[\s\S]*\}/);
+    if (!match) return null;
+
+    try {
+      return JSON.parse(match[0]) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/frontend/src/utils/sseClient.ts
+++ b/frontend/src/utils/sseClient.ts
@@ -18,6 +18,7 @@ export interface SSEClientOptions {
   onError?: (error: string, code?: number) => void;
   onComplete?: () => void;
   onConnectionError?: (error: Event) => void;
+  signal?: AbortSignal;
 }
 
 export class SSEClient {
@@ -129,6 +130,7 @@ export class SSEPostClient {
   private abortController: AbortController | null = null;
   private accumulatedContent: string = '';
   private resultData: any = null;
+  private settled = false;
 
   constructor(url: string, data: any, options: SSEClientOptions = {}) {
     this.url = url;
@@ -143,8 +145,18 @@ export class SSEPostClient {
   }
 
   private async connectInternal(resolve: (value: any) => void, reject: (reason?: any) => void) {
+      let externalSignal: AbortSignal | undefined;
+      let abortFromExternalSignal: (() => void) | undefined;
       try {
         this.abortController = new AbortController();
+        externalSignal = this.options.signal;
+        abortFromExternalSignal = () => this.abort();
+
+        if (externalSignal?.aborted) {
+          this.abortController.abort();
+        } else {
+          externalSignal?.addEventListener('abort', abortFromExternalSignal, { once: true });
+        }
 
         const response = await fetch(this.url, {
           method: 'POST',
@@ -186,14 +198,20 @@ export class SSEPostClient {
             }
 
             try {
-              // 解析数据
-              const dataMatch = line.match(/^data: (.+)$/m);
-              if (dataMatch) {
-                const data = JSON.parse(dataMatch[1]);
+              const dataLines = line
+                .split('\n')
+                .filter((item) => item.startsWith('data:'))
+                .map((item) => item.replace(/^data:\s?/, ''));
+              const rawData = dataLines.join('\n');
+              if (rawData) {
+                const data = JSON.parse(rawData);
 
                 // 标准消息处理
                 const message: SSEMessage = data;
-                await this.handleMessage(message, resolve, reject);
+                const shouldStop = await this.handleMessage(message, resolve, reject);
+                if (shouldStop) {
+                  return;
+                }
               }
             } catch (error) {
               console.error('解析SSE消息失败:', error, line);
@@ -202,19 +220,37 @@ export class SSEPostClient {
         }
 
       } catch (error: any) {
+        if (this.settled) {
+          return;
+        }
         if (error.name === 'AbortError') {
           console.log('请求已取消');
+          this.settled = true;
+          reject(error);
         } else {
           console.error('SSE POST请求失败:', error);
           if (this.options.onError) {
             this.options.onError(error.message || '请求失败');
           }
+          this.settled = true;
           reject(error);
+        }
+      } finally {
+        if (externalSignal && abortFromExternalSignal) {
+          externalSignal.removeEventListener('abort', abortFromExternalSignal);
         }
       }
   }
 
-  private async handleMessage(message: SSEMessage, resolve: (value: any) => void, reject: (reason?: any) => void) {
+  private async handleMessage(
+    message: SSEMessage,
+    resolve: (value: any) => void,
+    reject: (reason?: any) => void
+  ): Promise<boolean> {
+    if (this.settled) {
+      return true;
+    }
+
     switch (message.type) {
       case 'progress':
         if (this.options.onProgress && message.progress !== undefined) {
@@ -225,7 +261,7 @@ export class SSEPostClient {
             message.word_count
           );
         }
-        break;
+        return false;
 
       case 'chunk':
         if (message.content) {
@@ -234,26 +270,29 @@ export class SSEPostClient {
             this.options.onChunk(message.content);
           }
         }
-        break;
+        return false;
 
       case 'result':
         if (this.options.onResult && message.data) {
           this.options.onResult(message.data);
         }
         this.resultData = message.data;
-        break;
+        return false;
 
       case 'error':
         if (this.options.onError) {
           this.options.onError(message.error || '未知错误', message.code);
         }
+        this.settled = true;
+        this.abort();
         reject(new Error(message.error || '未知错误'));
-        break;
+        return true;
 
       case 'done':
         if (this.options.onComplete) {
           this.options.onComplete();
         }
+        this.settled = true;
         if (this.resultData) {
           resolve(this.resultData);
         } else if (this.accumulatedContent) {
@@ -261,7 +300,10 @@ export class SSEPostClient {
         } else {
           resolve(true);
         }
-        break;
+        return true;
+
+      default:
+        return false;
     }
   }
 


### PR DESCRIPTION
Closes #141

## Summary

This PR implements the local fixes and feature improvements described in #141, then iterates on the follow-up Copilot review feedback and the later runtime bugs found during manual use.

## Main changes

- Mounts and hardens the `/api/polish` router, including support for AI responses shaped as `{ content, usage }` and safer project access validation before writing generation history.
- Adds inline AI polishing/rewriting entry points for outline generation inputs and chapter editing flows, using the existing polish/SSE workflow instead of introducing a separate AI path.
- Adds background-task based outline optimization and character/organization optimization, with task panel labels for the new optimization task types.
- Adds AI-assisted generation/analysis entry points for organizations, relationships, and careers based on existing world settings, outlines, and chapters.
- Improves relationship generation by asking the AI to return character IDs and only falling back to unique names, avoiding wrong bindings when duplicate character names exist.
- Adds true SSE cancellation support in the shared frontend SSE client and related generation modals, including relationship generation and precise chapter rewrite.
- Fixes precise chapter rewrite so non-streamed final `new_text` responses are still applied, and empty responses no longer leave the modal stuck in a fake success state.
- Improves chapter export with a modal-driven range selector and split ZIP export for per-chapter files.
- Adds chapter list filters for status, analysis state, content presence, and outline linkage, and adjusts the toolbar layout.
- Improves Gemini empty/safety-blocked response handling, propagates chapter analysis failure reasons, and falls back to the default model for blocked Gemini analysis when possible.
- Improves TXT chapter detection and import fallback summaries, and makes imported entity generation more conservative by grounding generated entities in source text.
- Adds an opt-in `ALLOW_DNS_PROXY_FAKE_IP` setting for local Clash/fake-IP DNS development while keeping production default behavior locked down.
- Prevents nested host `node_modules` and local browser automation cache from being included accidentally.

## Follow-up fixes after review

- Fixed `PolishTextRequest.project_id` typing to match backend UUID strings.
- Removed/avoided unused backend imports noted by review.
- Added project access validation before polish history writes.
- Reduced import name-candidate scanning overhead with capped source context and candidate counters.
- Made Clash fake-IP DNS allowance explicit and disabled by default.
- Fixed relationship-generation cancellation so Cancel actually aborts the active SSE request.
- Fixed duplicate-name relationship binding by using character IDs as the primary key and unique-name fallback only.
- Fixed precise chapter rewrite activation/result handling so generated text can be accepted reliably.

## Verification

- `npm run build`
- `python -m py_compile backend/app/api/projects.py backend/app/api/chapters.py backend/app/api/polish.py backend/app/api/relationships.py backend/app/schemas/polish.py backend/app/services/ai_clients/gemini_client.py backend/app/services/background_task_service.py backend/app/services/book_import_service.py backend/app/services/plot_analyzer.py backend/app/services/txt_parser_service.py backend/app/security.py backend/app/main.py`
- `git diff --check`
- scanned the outgoing diff for API keys, local paths, project IDs, and local project content