### PR TITLE
fix: 修复向导大纲生成时可能重复创建章节的问题

### DIFF
--- a/backend/app/api/wizard_stream.py
+++ b/backend/app/api/wizard_stream.py
@@ -1440,10 +1440,26 @@ async def outline_generator(
         # 根据项目的大纲模式决定是否自动创建章节
         created_chapters = []
         if project.outline_mode == 'one-to-one':
-            # 一对一模式：自动为每个大纲创建对应的章节
+            # 一对一模式：自动为每个大纲创建对应的章节（检查是否已存在，避免重复）
             yield await tracker.saving("一对一模式：自动创建章节...", 0.7)
-            
+
+            # 先查询已存在的章节，避免重复创建
+            existing_chapters_result = await db.execute(
+                select(Chapter).where(Chapter.project_id == project_id)
+            )
+            existing_chapters = existing_chapters_result.scalars().all()
+            existing_chapter_numbers = {ch.chapter_number for ch in existing_chapters}
+
+            created_count = 0
+            skipped_count = 0
+
             for outline in created_outlines:
+                # 检查是否已存在相同chapter_number的章节
+                if outline.order_index in existing_chapter_numbers:
+                    skipped_count += 1
+                    logger.info(f"一对一模式：跳过大纲 {outline.title}（序号{outline.order_index}），章节已存在")
+                    continue
+
                 chapter = Chapter(
                     project_id=project_id,
                     title=outline.title,
@@ -1454,13 +1470,16 @@ async def outline_generator(
                 )
                 db.add(chapter)
                 created_chapters.append(chapter)
-            
-            await db.flush()
-            for chapter in created_chapters:
-                await db.refresh(chapter)
-            
-            logger.info(f"✅ 一对一模式：自动创建了{len(created_chapters)}个章节")
-            yield await tracker.saving(f"已自动创建{len(created_chapters)}个章节", 0.9)
+                existing_chapter_numbers.add(outline.order_index)  # 防止同一批次重复
+                created_count += 1
+
+            if created_chapters:
+                await db.flush()
+                for chapter in created_chapters:
+                    await db.refresh(chapter)
+
+            logger.info(f"✅ 一对一模式：自动创建了{created_count}个章节（跳过{skipped_count}个已存在的章节）")
+            yield await tracker.saving(f"已自动创建{created_count}个章节（跳过{skipped_count}个已存在的章节）", 0.9)
         else:
             # 一对多模式：跳过自动创建，用户可手动展开
             yield await tracker.saving("细化模式：跳过自动创建章节", 0.9)


### PR DESCRIPTION
## 问题\n在向导（wizard）的大纲生成流程中，one-to-one 模式下自动创建章节时没有检查是否已存在相同 chapter_number 的章节，导致重复创建章节。\n\n## 修复\n在 wizard_stream.py 的 outline_generator 中添加去重逻辑：\n- 创建章节前先查询该 project 下已存在的所有章节\n- 收集已存在的 chapter_number 集合\n- 跳过已存在相同 chapter_number 的章节，避免重复创建\n- 同时防止同一批次内的重复\n\n## 影响范围\n- 仅修改 backend/app/api/wizard_stream.py 中的 outline_generator 函数